### PR TITLE
Extended Assert-Module to import modules as well (Fixes #218)

### DIFF
--- a/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
+++ b/DSCResources/MSFT_xADCommon/MSFT_xADCommon.psm1
@@ -27,8 +27,14 @@ function Assert-Module
     [CmdletBinding()]
     param
     (
-        [Parameter()] [ValidateNotNullOrEmpty()]
-        [System.String] $ModuleName = 'ActiveDirectory'
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ModuleName = 'ActiveDirectory',
+
+        [Parameter()]
+        [switch]
+        $ImportModule
     )
 
     if (-not (Get-Module -Name $ModuleName -ListAvailable))
@@ -36,6 +42,11 @@ function Assert-Module
         $errorId = '{0}_ModuleNotFound' -f $ModuleName;
         $errorMessage = $localizedString.RoleNotFoundError -f $moduleName;
         ThrowInvalidOperationError -ErrorId $errorId -ErrorMessage $errorMessage;
+    }
+
+    if ($ImportModule)
+    {
+        Import-Module -Name $ModuleName
     }
 } #end function Assert-Module
 

--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -108,7 +108,7 @@ function Get-TargetResource
         [String] $DomainMode
     )
 
-    Assert-Module -ModuleName 'ADDSDeployment';
+    Assert-Module -ModuleName 'ADDSDeployment' -ImportModule
     $domainFQDN = Resolve-DomainFQDN -DomainName $DomainName -ParentDomainName $ParentDomainName;
     $isDomainMember = Test-DomainMember;
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ The xADServicePrincipalName DSC resource will manage service principal names.
 
 ### Unreleased
 
+* Changes to xADCommon
+  * Assert-Module has been extended with a parameter ImportModule to also import the module ([issue #218](https://github.com/PowerShell/xActiveDirectory/issues/218)). [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
+* Changes to xADDomain
+  * xADDomain makes use of new parameter ImportModule of Assert-Module in order to import the ADDSDeployment module ([issue #218](https://github.com/PowerShell/xActiveDirectory/issues/218)). [Jan-Hendrik Peters (@nyanhp)](https://github.com/nyanhp)
+
 ### 2.20.0.0
 
 * Changes to xActiveDirectory

--- a/Tests/Unit/MSFT_xADCommon.Tests.ps1
+++ b/Tests/Unit/MSFT_xADCommon.Tests.ps1
@@ -113,6 +113,16 @@ try
                 { Assert-Module -ModuleName $testModuleName } | Should Not Throw;
             }
 
+            It 'Should call Import-Module when the module is installed and ImportModule is specified' {
+                $testModuleName = 'TestModule'
+                Mock -CommandName Get-Module -ParameterFilter { $Name -eq $testModuleName } -MockWith { return $true; }
+                Mock -CommandName Import-Module -ParameterFilter { $Name -eq $testModuleName }
+
+                Assert-Module -ModuleName $testModuleName -ImportModule
+
+                Assert-MockCalled -CommandName Import-Module
+            }
+
             It 'Throws when module is not installed' {
                 $testModuleName = 'TestModule';
                 Mock -CommandName Get-Module -ParameterFilter { $Name -eq $testModuleName }


### PR DESCRIPTION
Extended the Assert-Module cmdlet to have a new parameter called ImportModule to initiate a module import. This aids in scenarios like issue #218 when .NET classes of a module need to be present.

In xADDomain, Get-TargetResource is always executed first in Test-TargetResource as well as Set-TargetResource and imports the module ADDSDeployment with the extended Assert-Module call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xactivedirectory/223)
<!-- Reviewable:end -->
