### PR TITLE
MSFT_ADReplicationSite: Fixing Description parameter evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   - Added Integration testing ([issue #351](https://github.com/PowerShell/ActiveDirectoryDsc/issues/351))
 - Changes to ADObjectPermissionEntry
   - Updated Assert-ADPSDrive with PSProvider Checks ([issue #527](https://github.com/PowerShell/ActiveDirectoryDsc/issues/527)).
+- Changes to ADReplicationSite
+  - Fixed incorrect evaluation of site configuration state when no description is defined ([issue #534](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/534)).
 
 ## 4.2.0.0
 

--- a/DSCResources/MSFT_ADReplicationSite/MSFT_ADReplicationSite.psm1
+++ b/DSCResources/MSFT_ADReplicationSite/MSFT_ADReplicationSite.psm1
@@ -215,7 +215,7 @@ function Test-TargetResource
         if ($getTargetResourceResult.Ensure -eq $Ensure)
         {
             # Site should exist
-            if ($getTargetResourceResult.Description -ne $Description)
+            if ($PSBoundParameters.ContainsKey('Description') -and $getTargetResourceResult.Description -ne $Description)
             {
                 Write-Verbose -Message ($script:localizedData.ReplicationSiteNotInDesiredState -f $Name)
                 $configurationCompliant = $false

--- a/Tests/Integration/MSFT_ADReplicationSite.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_ADReplicationSite.Integration.Tests.ps1
@@ -128,6 +128,99 @@ try
             }
         }
 
+        $configurationName = "$($script:dscResourceName)_CreateSiteNoDescription_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                        -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Name | Should -Be 'NewADSite'
+                $resourceCurrentState.Description | Should -BeNullOrEmpty
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        $configurationName = "$($script:dscResourceName)_RemoveSiteNoDescription_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                        -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.IsSingleInstance | Should -BeNullOrEmpty
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
         $configurationName = "$($script:dscResourceName)_RenameDefaultSite_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {

--- a/Tests/Integration/MSFT_ADReplicationSite.config.ps1
+++ b/Tests/Integration/MSFT_ADReplicationSite.config.ps1
@@ -63,6 +63,42 @@ Configuration MSFT_ADReplicationSite_RemoveSite_Config
 
 <#
     .SYNOPSIS
+        Creates a brand new Site in AD Sites and Services with no description set.
+#>
+Configuration MSFT_ADReplicationSite_CreateSiteNoDescription_Config
+{
+    Import-DscResource -ModuleName 'ActiveDirectoryDsc'
+
+    node $AllNodes.NodeName
+    {
+        ADReplicationSite 'Integration_Test'
+        {
+            Name        = 'NewADSite'
+            Ensure      = 'Present'
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Remove site from AD Sites and Services
+#>
+Configuration MSFT_ADReplicationSite_RemoveSiteNoDescription_Config
+{
+    Import-DscResource -ModuleName 'ActiveDirectoryDsc'
+
+    node $AllNodes.NodeName
+    {
+        ADReplicationSite 'Integration_Test'
+        {
+            Name        = 'NewADSite'
+            Ensure      = 'Absent'
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
         Rename the Default Site in Active Directory
 #>
 Configuration MSFT_ADReplicationSite_RenameDefaultSite_Config
@@ -80,4 +116,3 @@ Configuration MSFT_ADReplicationSite_RenameDefaultSite_Config
         }
     }
 }
-

--- a/Tests/Unit/MSFT_ADReplicationSite.Tests.ps1
+++ b/Tests/Unit/MSFT_ADReplicationSite.Tests.ps1
@@ -73,6 +73,18 @@ try
             Name        = $presentSiteName
             Description = $genericDescription
         }
+
+        $presentSiteTestPresentEmptyDescription = @{
+            Ensure      = 'Present'
+            Name        = $presentSiteName
+            Description = $null
+        }
+
+        $presentSiteTestNoDescription = @{
+            Ensure      = 'Present'
+            Name        = $presentSiteName
+        }
+
         $presentSiteTestAbsent = @{
             Ensure = 'Absent'
             Name   = $presentSiteName
@@ -222,6 +234,30 @@ try
 
                 # Assert
                 $targetResourceState | Should -BeFalse
+            }
+
+            It 'Should return true if the site exists with description set, but no description is defined' {
+
+                # Arrange
+                Mock -CommandName Get-ADReplicationSite { $presentSiteTestPresentEmptyDescription }
+
+                # Act
+                $targetResourceState = Test-TargetResource @presentSiteTestNoDescription
+
+                # Assert
+                $targetResourceState | Should -BeTrue
+            }
+
+            It 'Should return true if the site exists with no description set, and no description defined' {
+
+                # Arrange
+                Mock -CommandName Get-ADReplicationSite { $presentSiteTestPresent }
+
+                # Act
+                $targetResourceState = Test-TargetResource @presentSiteTestNoDescription
+
+                # Assert
+                $targetResourceState | Should -BeTrue
             }
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Fix for correct evaluation of `Description` parameter in `Test-TargetResource` of `MSFT_ADReplicationSite` resource. When no description was defined, the test incorrectly evaluated as $false every time.

#### This Pull Request (PR) fixes the following issues
Fixes #534

#### Task list
- [X] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Conceptual help topic added/updated (cultureFolder\about_ResourceName.help.txt).
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [X] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/535)
<!-- Reviewable:end -->
