### PR TITLE
ADReplicationSiteLink: Fix RemovingSites Verbose Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Updated Assert-ADPSDrive with PSProvider Checks ([issue #527](https://github.com/PowerShell/ActiveDirectoryDsc/issues/527)).
 - ADReplicationSite
   - Fixed incorrect evaluation of site configuration state when no description is defined ([issue #534](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/534)).
+- ADReplicationSiteLink
+  - Fix RemovingSites verbose message ([issue #518](https://github.com/PowerShell/ActiveDirectoryDsc/issues/518)).
 
 ## 4.2.0.0
 

--- a/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
+++ b/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
@@ -212,7 +212,7 @@ function Set-TargetResource
             $sitesIncludedParameters = @{}
             if ($SitesExcluded)
             {
-                Write-Verbose -Message ($script:localizedData.RemovingSites -f $($SiteExcluded -join ', '), $Name)
+                Write-Verbose -Message ($script:localizedData.RemovingSites -f $($SitesExcluded -join ', '), $Name)
 
                 <#
                     Wrapped in $() as we were getting some weird results without it,


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the `ADReplicationSiteLink` RemovingSites verbose message.

#### This Pull Request (PR) fixes the following issues

- Fixes #518 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/541)
<!-- Reviewable:end -->
