### PR TITLE
ADObjectPermissionEntry / ADOrganizationalUnit: fixes issues 552 / 553

### DIFF
--- a/Tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/Tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -153,6 +153,26 @@ try
                     $targetResource.InheritedObjectType | Should -Be $testDefaultParameters.InheritedObjectType
                 }
             }
+            Context 'When the desired AD object path is absent' {
+
+                Mock -CommandName 'Get-Acl' -MockWith { throw New-Object System.Management.Automation.ItemNotFoundException }
+
+                It 'Should return a valid result if the AD object path is absent and not throw an exception' {
+                    # Act / Assert
+                    $targetResource = Get-TargetResource @testDefaultParameters
+                    $targetResource.Ensure | Should -Be 'Absent'
+                }
+            }
+            Context 'When an unknown error occurs' {
+
+                $error = 'Unknown Error'
+                Mock -CommandName 'Get-Acl' -MockWith { throw $error }
+
+                It 'Should throw an exception if an unknown error occurs calling Get-Acl' {
+                    # Act / Assert
+                    { Get-TargetResource @testDefaultParameters } | Should -Throw
+                }
+            }
         }
         #endregion
 

--- a/Tests/Unit/MSFT_ADOrganizationalUnit.Tests.ps1
+++ b/Tests/Unit/MSFT_ADOrganizationalUnit.Tests.ps1
@@ -114,15 +114,15 @@ try
                 $targetResource.Description | Should -BeNullOrEmpty
             }
 
-            It 'Should throw the correct error if the path does not exist' {
+            It 'Returns "Ensure" = "Absent" when OU parent path does not exist and does not throw an exception' {
                 Mock -CommandName Assert-Module
                 Mock -CommandName Get-ADOrganizationalUnit -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
 
-                $errorMessage = $script:localizedData.PathNotFoundError -f $testPresentParams.Path
-                { Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path } | Should -Throw $errorMessage
+                $targetResource = Get-TargetResource -Name $testPresentParams.Name -Path $testPresentParams.Path
+                $targetResource.Ensure | Should -Be 'Absent'
             }
 
-            It 'Should throw the correct error if an unkwon error occurs' {
+            It 'Should throw the correct error if an unknown error occurs' {
                 $error = 'Unknown Error'
                 Mock -CommandName Assert-Module
                 Mock -CommandName Get-ADOrganizationalUnit -MockWith { throw $error }

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -78,8 +78,19 @@ function Get-TargetResource
         InheritedObjectType                = $InheritedObjectType
     }
 
-    # Get the current acl
-    $acl = Get-Acl -Path "AD:$Path"
+    try
+    {
+        # Get the current acl
+        $acl = Get-Acl -Path "AD:$Path" -ErrorAction Stop
+    }
+    catch [System.Management.Automation.ItemNotFoundException]
+    {
+        Write-Verbose -Message ($script:localizedData.ObjectPathIsAbsent -f $Path)
+    }
+    catch
+    {
+        throw $_
+    }
 
     foreach ($access in $acl.Access)
     {

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/en-US/MSFT_ADObjectPermissionEntry.strings.psd1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/en-US/MSFT_ADObjectPermissionEntry.strings.psd1
@@ -7,4 +7,5 @@ ConvertFrom-StringData @'
     RemovingObjectPermissionEntry          = Removing object permission entry from object '{0}'. (OPE0004)
     ObjectPermissionEntryInDesiredState    = Object permission entry on object '{0}' is in the desired state. (OPE0005)
     ObjectPermissionEntryNotInDesiredState = Object permission entry on object '{0}' is not in the desired state. (OPE0006)
+    ObjectPathIsAbsent                     = Object Path '{0}' is absent from Active Directory. (OPE0007)
 '@

--- a/source/DSCResources/MSFT_ADOrganizationalUnit/MSFT_ADOrganizationalUnit.psm1
+++ b/source/DSCResources/MSFT_ADOrganizationalUnit/MSFT_ADOrganizationalUnit.psm1
@@ -43,8 +43,7 @@ function Get-TargetResource
     }
     catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException]
     {
-        $errorMessage = $script:localizedData.PathNotFoundError -f $Path
-        New-ObjectNotFoundException -Message $errorMessage
+        Write-Verbose -Message ($script:localizedData.OUPathIsAbsent -f $Path)
     }
     catch
     {

--- a/source/DSCResources/MSFT_ADOrganizationalUnit/en-US/MSFT_ADOrganizationalUnit.strings.psd1
+++ b/source/DSCResources/MSFT_ADOrganizationalUnit/en-US/MSFT_ADOrganizationalUnit.strings.psd1
@@ -10,5 +10,5 @@ ConvertFrom-StringData @'
     OUExistsButShouldNot       = OU '{0}' exists when it should not exist. (ADOU0008)
     OUDoesNotExistButShould    = OU '{0}' does not exist when it should exist. (ADOU0009)
     OUDoesNotExistAndShouldNot = OU '{0}' does not exist and is in the desired state. (ADOU0010)
-    PathNotFoundError          = The Path '{0}' was not found. (ADOU0011)
+    OUPathIsAbsent             = The OU Path '{0}' is absent from Active Directory. (ADOU0011)
 '@


### PR DESCRIPTION
<!--
#### Pull Request (PR) description
Fixes issues 552 / 553, both of which relate to calling Get-DscConfiguration / Test-DscConfiguration on configurations which include references to AD objects paths that haven't been created yet. At present both resources throw an exception, but believe that they should simply mark the resource as absent and continue.

#### This Pull Request (PR) fixes the following issues
- Fixes #552
- Fixes #553
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/554)
<!-- Reviewable:end -->
