### PR TITLE
ADObjectPermissionEntry: Fix Exception When the Object Path Does Not Exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 - ADForestProperties
   - Fixed ability to clear `ServicePrincipalNameSuffix` and `UserPrincipalNameSuffix` ([issue #548](https://github.com/PowerShell/ActiveDirectoryDsc/issues/548)).
+- ADObjectPermissionEntry
+    - Fixed issue where Get-DscConfiguration / Test-DscConfiguration throw an exception when target object path does not yet exist ([issue #552](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/552))
 
 ### Changed
 

--- a/Tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/Tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -153,6 +153,26 @@ try
                     $targetResource.InheritedObjectType | Should -Be $testDefaultParameters.InheritedObjectType
                 }
             }
+            Context 'When the desired AD object path is absent' {
+
+                Mock -CommandName 'Get-Acl' -MockWith { throw New-Object System.Management.Automation.ItemNotFoundException }
+
+                It 'Should return a valid result if the AD object path is absent and not throw an exception' {
+                    # Act / Assert
+                    $targetResource = Get-TargetResource @testDefaultParameters
+                    $targetResource.Ensure | Should -Be 'Absent'
+                }
+            }
+            Context 'When an unknown error occurs' {
+
+                $error = 'Unknown Error'
+                Mock -CommandName 'Get-Acl' -MockWith { throw $error }
+
+                It 'Should throw an exception if an unknown error occurs calling Get-Acl' {
+                    # Act / Assert
+                    { Get-TargetResource @testDefaultParameters } | Should -Throw
+                }
+            }
         }
         #endregion
 

--- a/Tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/Tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -157,7 +157,7 @@ try
 
                 Mock -CommandName 'Get-Acl' -MockWith { throw New-Object System.Management.Automation.ItemNotFoundException }
 
-                It 'Should return a valid result if the AD object path is absent and not throw an exception' {
+                It 'Should return a valid result if the AD object path is absent' {
                     # Act / Assert
                     $targetResource = Get-TargetResource @testDefaultParameters
                     $targetResource.Ensure | Should -Be 'Absent'

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -78,8 +78,19 @@ function Get-TargetResource
         InheritedObjectType                = $InheritedObjectType
     }
 
-    # Get the current acl
-    $acl = Get-Acl -Path "AD:$Path"
+    try
+    {
+        # Get the current acl
+        $acl = Get-Acl -Path "AD:$Path" -ErrorAction Stop
+    }
+    catch [System.Management.Automation.ItemNotFoundException]
+    {
+        Write-Verbose -Message ($script:localizedData.ObjectPathIsAbsent -f $Path)
+    }
+    catch
+    {
+        throw $_
+    }
 
     foreach ($access in $acl.Access)
     {

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -92,31 +92,37 @@ function Get-TargetResource
         throw $_
     }
 
-    foreach ($access in $acl.Access)
+    if ($null -ne $acl)
     {
-        if ($access.IsInherited -eq $false)
+        foreach ($access in $acl.Access)
         {
-            <#
-                Check if the ace does match the parameters. If yes, the target
-                ace has been found, return present with the assigned rights.
-            #>
-            if ($access.IdentityReference.Value -eq $IdentityReference -and
-                $access.AccessControlType -eq $AccessControlType -and
-                $access.ObjectType.Guid -eq $ObjectType -and
-                $access.InheritanceType -eq $ActiveDirectorySecurityInheritance -and
-                $access.InheritedObjectType.Guid -eq $InheritedObjectType)
+            if ($access.IsInherited -eq $false)
             {
-                Write-Verbose -Message ($script:localizedData.ObjectPermissionEntryFound -f $Path)
-
-                $returnValue['Ensure'] = 'Present'
-                $returnValue['ActiveDirectoryRights'] = [System.String[]] $access.ActiveDirectoryRights.ToString().Split(',').ForEach( { $_.Trim() })
-
-                return $returnValue
+                <#
+                    Check if the ace does match the parameters. If yes, the target
+                    ace has been found, return present with the assigned rights.
+                #>
+                if ($access.IdentityReference.Value -eq $IdentityReference -and
+                    $access.AccessControlType -eq $AccessControlType -and
+                    $access.ObjectType.Guid -eq $ObjectType -and
+                    $access.InheritanceType -eq $ActiveDirectorySecurityInheritance -and
+                    $access.InheritedObjectType.Guid -eq $InheritedObjectType)
+                {
+                    $returnValue['Ensure'] = 'Present'
+                    $returnValue['ActiveDirectoryRights'] = [System.String[]] $access.ActiveDirectoryRights.ToString().Split(',').ForEach( { $_.Trim() })
+                }
             }
         }
     }
 
-    Write-Verbose -Message ($script:localizedData.ObjectPermissionEntryNotFound -f $Path)
+    if ($returnValue.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message ($script:localizedData.ObjectPermissionEntryFound -f $Path)
+    }
+    else
+    {
+        Write-Verbose -Message ($script:localizedData.ObjectPermissionEntryNotFound -f $Path)
+    }
 
     return $returnValue
 }

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/en-US/MSFT_ADObjectPermissionEntry.strings.psd1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/en-US/MSFT_ADObjectPermissionEntry.strings.psd1
@@ -7,4 +7,5 @@ ConvertFrom-StringData @'
     RemovingObjectPermissionEntry          = Removing object permission entry from object '{0}'. (OPE0004)
     ObjectPermissionEntryInDesiredState    = Object permission entry on object '{0}' is in the desired state. (OPE0005)
     ObjectPermissionEntryNotInDesiredState = Object permission entry on object '{0}' is not in the desired state. (OPE0006)
+    ObjectPathIsAbsent                     = Object Path '{0}' is absent from Active Directory. (OPE0007)
 '@


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes issue with ADObjectPermissionEntry resource, where unable to run Get-DscConfiguration or Test-DscConfiguration where the object path of the associated AD resource (on which the PermissionEntry is defined) doesn't exist yet.

#### This Pull Request (PR) fixes the following issues
- Fixes #552

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/555)
<!-- Reviewable:end -->
