### PR TITLE
ADObjectPermissionEntry: Allow Permission updates without using a Domain Admin account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Fixed issue where Get-TargetResource throw an exception, `Cannot find drive. A drive with the name 'AD' does not
     exist`, when running soon after domain controller restart
     ([issue #547](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/547))
+  - Fixed issue where Set-TargetResource requires Domain Admin access in order to update the ACL
+    ([issue #575](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/575))
 - ADOrganizationalUnit
   - Fixed issue where Get-DscConfiguration / Test-DscConfiguration throw an exception when parent path does not yet exist
     ([issue #553](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/553))

--- a/Tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/Tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -35,6 +35,7 @@ try
 
         # Load stub cmdlets and classes.
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath 'Stubs\ActiveDirectory_2019.psm1') -Force
+        Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '..\..\source\Modules\ActiveDirectoryDsc.Common\ActiveDirectoryDsc.Common.psm1') -Force
 
         #region Pester Test Initialization
         $mockCredentialUserName = 'COMPANY\User'
@@ -67,22 +68,24 @@ try
             $mock = [PSCustomObject] @{
                 Path   = 'AD:CN=PC01,CN=Computers,DC=contoso,DC=com'
                 Owner  = 'BUILTIN\Administrators'
-                Access = @(
-                    [PSCustomObject] @{
-                        ActiveDirectoryRights = 'GenericAll'
-                        InheritanceType       = 'None'
-                        ObjectType            = [System.Guid] '00000000-0000-0000-0000-000000000000'
-                        InheritedObjectType   = [System.Guid] '00000000-0000-0000-0000-000000000000'
-                        ObjectFlags           = 'None'
-                        AccessControlType     = 'Allow'
-                        IdentityReference     = [PSCustomObject] @{
-                            Value = 'CONTOSO\User'
+                ObjectSecurity = [PSCustomObject]@{
+                    Access = @(
+                        [PSCustomObject] @{
+                            ActiveDirectoryRights = 'GenericAll'
+                            InheritanceType       = 'None'
+                            ObjectType            = [System.Guid] '00000000-0000-0000-0000-000000000000'
+                            InheritedObjectType   = [System.Guid] '00000000-0000-0000-0000-000000000000'
+                            ObjectFlags           = 'None'
+                            AccessControlType     = 'Allow'
+                            IdentityReference     = [PSCustomObject] @{
+                                Value = 'CONTOSO\User'
+                            }
+                            IsInherited           = $false
+                            InheritanceFlags      = 'None'
+                            PropagationFlags      = 'None'
                         }
-                        IsInherited           = $false
-                        InheritanceFlags      = 'None'
-                        PropagationFlags      = 'None'
-                    }
-                )
+                    )
+                }
             }
             $mock | Add-Member -MemberType 'ScriptMethod' -Name 'AddAccessRule' -Value { }
             $mock | Add-Member -MemberType 'ScriptMethod' -Name 'RemoveAccessRule' -Value { }
@@ -107,7 +110,7 @@ try
 
             Context 'When the desired ace is present' {
 
-                Mock -CommandName 'Get-Acl' -MockWith $mockGetAclPresent
+                Mock -CommandName 'Get-DirectoryEntry' -MockWith $mockGetAclPresent
 
                 It 'Should return a "System.Collections.Hashtable" object type' {
                     # Act
@@ -135,7 +138,7 @@ try
 
             Context 'When the desired ace is absent' {
 
-                Mock -CommandName 'Get-Acl' -MockWith $mockGetAclAbsent
+                Mock -CommandName 'Get-DirectoryEntry' -MockWith $mockGetAclAbsent
 
                 It 'Should return a valid result if the ace is absent' {
                     # Act
@@ -154,7 +157,7 @@ try
             }
             Context 'When the desired AD object path is absent' {
 
-                Mock -CommandName 'Get-Acl' -MockWith { throw New-Object System.Management.Automation.ItemNotFoundException }
+                Mock -CommandName 'Get-DirectoryEntry' -MockWith { throw New-Object System.Management.Automation.ItemNotFoundException }
 
                 It 'Should return a valid result if the AD object path is absent' {
                     # Act / Assert
@@ -165,7 +168,7 @@ try
             Context 'When an unknown error occurs' {
 
                 $errormsg = 'Unknown Error'
-                Mock -CommandName 'Get-Acl' -MockWith { throw $errormsg }
+                Mock -CommandName 'Get-DirectoryEntry' -MockWith { throw $errormsg }
 
                 It 'Should throw an exception if an unknown error occurs calling Get-Acl' {
                     # Act / Assert
@@ -181,7 +184,7 @@ try
 
             Context 'When the desired ace is present' {
 
-                Mock -CommandName 'Get-Acl' -MockWith $mockGetAclPresent
+                Mock -CommandName 'Get-DirectoryEntry' -MockWith $mockGetAclPresent
 
                 It 'Should return a "System.Boolean" object type' {
                     # Act
@@ -210,7 +213,7 @@ try
 
             Context 'When the desired ace is absent' {
 
-                Mock -CommandName 'Get-Acl' -MockWith $mockGetAclAbsent
+                Mock -CommandName 'Get-DirectoryEntry' -MockWith $mockGetAclAbsent
 
                 It 'Should return $false if the ace desired state is present' {
                     # Act

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -88,7 +88,7 @@ function Get-TargetResource
     try
     {
         # Get the current acl
-        $DirectoryEntry = New-Object -TypeName System.DirectoryServices.DirectoryEntry -ArgumentList @("LDAP://$Path", $Credential.UserName, $Credential.GetNetworkCredential().Password)
+        $DirectoryEntry = Get-DirectoryEntry -Path $Path -Credential $Credential
     }
     catch [System.Management.Automation.ItemNotFoundException]
     {
@@ -218,7 +218,7 @@ function Set-TargetResource
     try
     {
         # Get the current acl
-        $DirectoryEntry = New-Object -TypeName System.DirectoryServices.DirectoryEntry -ArgumentList @("LDAP://$Path", $Credential.UserName, $Credential.GetNetworkCredential().Password)
+        $DirectoryEntry = Get-DirectoryEntry -Path $Path -Credential $Credential
     }
     catch [System.Management.Automation.ItemNotFoundException]
     {

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -111,7 +111,7 @@ function Get-TargetResource
             $_.InheritedObjectType.Guid -eq $InheritedObjectType
         }
 
-        if($null -ne $FoundEntry)
+        if ($null -ne $FoundEntry)
         {
             $returnValue['Ensure'] = 'Present'
             $returnValue['ActiveDirectoryRights'] = [System.String[]] $FoundEntry.ActiveDirectoryRights.ToString().Split(',').ForEach( { $_.Trim() })
@@ -280,7 +280,7 @@ function Set-TargetResource
             $_.InheritanceType -eq $ActiveDirectorySecurityInheritance -and
             $_.InheritedObjectType.Guid -eq $InheritedObjectType
         }
-        if($null -ne $FoundEntry)
+        if ($null -ne $FoundEntry)
         {
             Write-Verbose -Message ($script:localizedData.RemovingObjectPermissionEntry -f $Path)
 

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -230,10 +230,10 @@ function Set-TargetResource
         $ntAccount = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier])
         $ace = New-Object -TypeName 'System.DirectoryServices.ActiveDirectoryAccessRule' -ArgumentList $ntAccount, $ActiveDirectoryRights, $AccessControlType, $ObjectType, $ActiveDirectorySecurityInheritance, $InheritedObjectType
 
-        if($null -ne $record)
+        if ($null -ne $record)
         {
             #Remove the existing record and create a new record with the updated permissions
-            if($record.ActiveDirectoryRights -ne $ActiveDirectoryRights)
+            if ($record.ActiveDirectoryRights -ne $ActiveDirectoryRights)
             {
                 $result = $acl.ObjectSecurity.ModifyAccessRule([System.Security.AccessControl.AccessControlModification]::RemoveSpecific,$record,[ref]$modified)
                 $result = $acl.ObjectSecurity.ModifyAccessRule([System.Security.AccessControl.AccessControlModification]::Add,$ace,[ref]$modified)
@@ -273,7 +273,7 @@ function Set-TargetResource
     }
 
     # Update the acl on the object
-    if($modified)
+    if ($modified)
     {
         $acl.CommitChanges()
     }

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.schema.mof
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.schema.mof
@@ -9,4 +9,5 @@ class MSFT_ADObjectPermissionEntry : OMI_BaseResource
     [Key, Description("The schema GUID of the object to which the access rule applies. If the permission entry shouldn't be restricted to a specific object type, use the zero guid (00000000-0000-0000-0000-000000000000).")] String ObjectType;
     [Key, Description("One of the 'ActiveDirectorySecurityInheritance' enumeration values that specifies the inheritance type of the access rule."), ValueMap{"All", "Children", "Descendents", "None", "SelfAndChildren"}, Values{"All", "Children", "Descendents", "None", "SelfAndChildren"}] String ActiveDirectorySecurityInheritance;
     [Key, Description("The schema GUID of the child object type that can inherit this access rule. If the permission entry shouldn't be restricted to a specific inherited object type, use the zero guid (00000000-0000-0000-0000-000000000000).")] String InheritedObjectType;
+    [Write, Description("Specifies the user account credentials to use to perform the task."), EmbeddedInstance("MSFT_Credential")] String Credential;
 };

--- a/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psm1
+++ b/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psm1
@@ -2166,4 +2166,44 @@ function Get-CurrentUser
     return [System.Security.Principal.WindowsIdentity]::GetCurrent()
 }
 
+<#
+    .SYNOPSIS
+        This returns a the Active Directory Entry so ADObjectPermissionEntry can
+        manage the permissions.
+
+    .PARAMETER DirectoryContext
+        The Active Directory context from which the forest object is returned.
+        Calling the Get-ADDirectoryContext gets a value that can be provided in
+        this parameter.
+
+    .PARAMETER SiteName
+        Specifies the site in the domain where to look for a domain controller.
+
+    .NOTES
+        This is a wrapper to enable unit testing of the function Find-DomainController.
+        It is not possible to make a stub class to mock these, since these classes
+        are loaded into the PowerShell session when it starts.
+
+        This function is not exported.
+#>
+function Get-DirectoryEntry
+{
+    [CmdletBinding()]
+    [OutputType([System.DirectoryServices.ActiveDirectory.DomainController])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Path,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.CredentialAttribute()]
+        $Credential
+    )
+
+    return New-Object -TypeName System.DirectoryServices.DirectoryEntry -ArgumentList @("LDAP://$Path", $Credential.UserName, $Credential.GetNetworkCredential().Password)
+}
+
 $script:localizedData = Get-LocalizedData -ResourceName 'ActiveDirectoryDsc.Common' -ScriptRoot $PSScriptRoot


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request is to fix an issue where the DSC module must be run as a Domain Admin in order to update an objects permissions.

#### This Pull Request (PR) fixes the following issues
- Fixes #575 
- Fixes #314 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/576)
<!-- Reviewable:end -->
