### PR TITLE
ADGroup: Add Support for Managed Service Accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Added Strict-Mode v1.0 to all unit tests.
 - ADDomain
   - Added integration tests
-    ([issue #302](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/302)).
+    ([issue #345](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/345)).
+- ADGroup
+  - Added support for Managed Service Accounts
+    ([issue #532](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/532)).
 - ADForestProperties
   - Added TombstoneLifetime property
     ([issue #302](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/302)).
@@ -25,25 +28,24 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 ### Fixed
 
 - ADForestProperties
-  - Fixed ability to clear `ServicePrincipalNameSuffix` and `UserPrincipalNameSuffix` ([issue #548](https://github.com/PowerShell/ActiveDirectoryDsc/issues/548)).
-- WaitForADDomain
-  - Fixed `Find-DomainController` to correctly handle an exception thrown when a domain controller is not ready ([issue #530](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/530)).
-  - Fixed ability to clear `ServicePrincipalNameSuffix` and `UserPrincipalNameSuffix` ([issue #548](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/548)).
   - Fixed ability to clear `ServicePrincipalNameSuffix` and `UserPrincipalNameSuffix`
-    ([issue #548](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/548)).
+    ([issue #548](https://github.com/PowerShell/ActiveDirectoryDsc/issues/548)).
+- WaitForADDomain
+  - Fixed `Find-DomainController` to correctly handle an exception thrown when a domain controller is not ready
+    ([issue #530](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/530)).
 - ADObjectPermissionEntry
   - Fixed issue where Get-DscConfiguration / Test-DscConfiguration throw an exception when target object path does not
     yet exist
-    ([issue #552](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/552))
+    ([issue #552](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/552)).
   - Fixed issue where Get-TargetResource throw an exception, `Cannot find drive. A drive with the name 'AD' does not
     exist`, when running soon after domain controller restart
-    ([issue #547](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/547))
+    ([issue #547](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/547)).
 - ADOrganizationalUnit
-  - Fixed issue where Get-DscConfiguration / Test-DscConfiguration throw an exception when parent path does not yet exist
-    ([issue #553](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/553))
+  - Fixed issue where Get-DscConfiguration/Test-DscConfiguration throws an exception when parent path does not yet exist
+    ([issue #553](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/553)).
 - ADReplicationSiteLink
   - Fixed issue creating a Site Link with options specified
-    ([issue #571](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/571))
+    ([issue #571](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/571)).
 - ADDomain
   - Added additional Get-ADDomain retry exceptions
     ([issue #574](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/574)).

--- a/Tests/Unit/ActiveDirectoryDsc.Common.Tests.ps1
+++ b/Tests/Unit/ActiveDirectoryDsc.Common.Tests.ps1
@@ -12,12 +12,7 @@ Get-Module -Name 'ActiveDirectoryDsc.Common' -All | Remove-Module -Force
 $script:projectPath = "$PSScriptRoot\..\.." | Convert-Path
 $script:projectName = (Get-ChildItem -Path "$script:projectPath\*\*.psd1" | Where-Object -FilterScript {
         ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-        $(try
-            { Test-ModuleManifest -Path $_.FullName -ErrorAction Stop
-            }
-            catch
-            { $false
-            })
+        $(try { Test-ModuleManifest -Path $_.FullName -ErrorAction Stop } catch { $false })
     }).BaseName
 
 $script:parentModule = Get-Module -Name $script:projectName -ListAvailable | Select-Object -First 1

--- a/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psm1
+++ b/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psm1
@@ -1316,6 +1316,14 @@ function Add-ADCommonGroupMember
                 {
                     $memberObject = Get-ADUser @commonParameters
                 }
+                elseif ($memberObjectClass -eq 'msDS-ManagedServiceAccount')
+                {
+                    $memberObject = Get-ADServiceAccount @commonParameters
+                }
+                elseif ($memberObjectClass -eq 'msDS-GroupManagedServiceAccount')
+                {
+                    $memberObject = Get-ADServiceAccount @commonParameters
+                }
 
                 Add-ADGroupMember @Parameters -Members $memberObject -ErrorAction 'Stop'
             }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds support for `msDS-ManagedServiceAccount` and `msDS-GroupManagedServiceAccount` objects to the `ADGroup` resource by patching the `Add-ADCommonGroupMember` function of the `ActiveDirectoryDsc.Common` module.

This PR is a replacement for #533 which was a pre-new CI PR.

#### This Pull Request (PR) fixes the following issues

- Fixes #532

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/578)
<!-- Reviewable:end -->
