### PR TITLE
ADDomain: Add Get-ADDomain Additional Retry Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Fixed
+
+- ADDomain
+  - Added additional Get-ADDomain retry exceptions
+    ([issue #581](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/581)).
+
 ### Changed
 
 - ActiveDirectoryDsc

--- a/Tests/Unit/MSFT_ADDomain.Tests.ps1
+++ b/Tests/Unit/MSFT_ADDomain.Tests.ps1
@@ -303,6 +303,27 @@ try
                     }
                 }
 
+                Context 'When Get-ADDomain throws an ArgumentException until timeout' {
+                    BeforeAll {
+                        Mock -CommandName Get-AdDomain `
+                            -MockWith { throw New-Object -TypeName 'System.ArgumentException' }
+                        Mock -CommandName Start-Sleep
+                    }
+
+                    It 'Should throw the correct exception' {
+                        { Get-TargetResource @mockGetTargetResourceParameters } |
+                            Should -Throw ($script:localizedData.MaxDomainRetriesReachedError -f $mockDomainFQDN)
+                    }
+
+                    It 'Should call the expected mocks' {
+                        Assert-MockCalled -CommandName Get-ADDomain `
+                            -ParameterFilter { $Identity -eq $mockDomainFQDN } `
+                            -Exactly -Times $maxRetries
+                        Assert-MockCalled -CommandName Start-Sleep `
+                            -Exactly -Times $maxRetries
+                    }
+                }
+
                 Context 'When Get-ADForest throws an unexpected error' {
                     BeforeAll {
                         Mock -CommandName Get-AdForest `

--- a/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
+++ b/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
@@ -102,7 +102,8 @@ function Get-TargetResource
             }
             catch [Microsoft.ActiveDirectory.Management.ADServerDownException], `
                 [System.Security.Authentication.AuthenticationException], `
-                [System.InvalidOperationException]
+                [System.InvalidOperationException], `
+                [System.ArgumentException]
             {
                 Write-Verbose ($script:localizedData.ADServerNotReady -f $domainFQDN)
                 $domainFound = $false


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds the following additional exception to the retry mechanism for the Get-ADDomain cmdlet that have been shown to occur when the domain controller is initialising:

- `System.ArgumentException`

#### This Pull Request (PR) fixes the following issues

- Fixes #581 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/586)
<!-- Reviewable:end -->
