### PR TITLE
ADDomainTrust: Move Get-ActiveDirectoryDomain and Get-ActiveDirectoryForest Functions into `ActiveDirectoryDsc.Common` Module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 - ADDomainTrust
   - Move `Get-ActiveDirectoryDomain` and `Get-ActiveDirectoryForest` functions
-    into `ActiveDirectoryDsc.Common` module.
+    into the `ActiveDirectoryDsc.Common` module.
 
 ## [6.0.1] - 2020-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Migrated HQRM and Unit Tests to use PowerShell 7 in the CI pipeline.
   - Changed CI pipeline to use PublishPipelineArtifact & DownloadPipelineArtifact.
 
+- ADDomainTrust
+  - Move `Get-ActiveDirectoryDomain` and `Get-ActiveDirectoryForest` functions
+    into `ActiveDirectoryDsc.Common` module.
+
 ## [6.0.1] - 2020-04-16
 
 ### Fixed

--- a/source/DSCResources/MSFT_ADDomainTrust/MSFT_ADDomainTrust.psm1
+++ b/source/DSCResources/MSFT_ADDomainTrust/MSFT_ADDomainTrust.psm1
@@ -507,64 +507,6 @@ function Compare-TargetResourceState
 
 <#
     .SYNOPSIS
-        This returns a new object of the type System.DirectoryServices.ActiveDirectory.Domain
-        which is a class that represents an Active Directory Domain Services domain.
-
-    .PARAMETER DirectoryContext
-        The Active Directory context from which the domain object is returned.
-        Calling the Get-ADDirectoryContext gets a value that can be provided in
-        this parameter.
-
-    .NOTES
-        This is a wrapper to enable unit testing of this resource.
-        see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/324
-        for more information.
-#>
-function Get-ActiveDirectoryDomain
-{
-    [CmdletBinding()]
-    [OutputType([System.DirectoryServices.ActiveDirectory.Domain])]
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [System.DirectoryServices.ActiveDirectory.DirectoryContext]
-        $DirectoryContext
-    )
-
-    return [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($DirectoryContext)
-}
-
-<#
-    .SYNOPSIS
-        This returns a new object of the type System.DirectoryServices.ActiveDirectory.Forest
-        which is a class that represents an Active Directory Domain Services forest.
-
-    .PARAMETER DirectoryContext
-        The Active Directory context from which the forest object is returned.
-        Calling the Get-ADDirectoryContext gets a value that can be provided in
-        this parameter.
-
-    .NOTES
-        This is a wrapper to enable unit testing of this resource.
-        see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/324
-        for more information.
-#>
-function Get-ActiveDirectoryForest
-{
-    [CmdletBinding()]
-    [OutputType([System.DirectoryServices.ActiveDirectory.Forest])]
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [System.DirectoryServices.ActiveDirectory.DirectoryContext]
-        $DirectoryContext
-    )
-
-    return [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($DirectoryContext)
-}
-
-<#
-    .SYNOPSIS
         This returns the converted value from a Trust Type value to the correct
         Directory Context Type value.
 

--- a/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psd1
+++ b/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psd1
@@ -54,6 +54,8 @@
         'Test-Password'
         'Test-PrincipalContextCredentials'
         'Get-ByteContent'
+        'Get-ActiveDirectoryDomain'
+        'Get-ActiveDirectoryForest'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psm1
+++ b/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psm1
@@ -2105,7 +2105,7 @@ function Get-ByteContent
         this parameter.
 
     .NOTES
-        This is a wrapper to enable unit testing of this resource.
+        This is a wrapper to allow test mocking of the calling function.
         see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/324
         for more information.
 #>
@@ -2134,7 +2134,7 @@ function Get-ActiveDirectoryDomain
         this parameter.
 
     .NOTES
-        This is a wrapper to enable unit testing of this resource.
+        This is a wrapper to allow test mocking of the calling function.
         see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/324
         for more information.
 #>

--- a/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psm1
+++ b/source/Modules/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.psm1
@@ -2093,3 +2093,61 @@ function Get-ByteContent
 
     return $content
 }
+
+<#
+    .SYNOPSIS
+        This returns a new object of the type System.DirectoryServices.ActiveDirectory.Domain
+        which is a class that represents an Active Directory Domain Services domain.
+
+    .PARAMETER DirectoryContext
+        The Active Directory context from which the domain object is returned.
+        Calling the Get-ADDirectoryContext gets a value that can be provided in
+        this parameter.
+
+    .NOTES
+        This is a wrapper to enable unit testing of this resource.
+        see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/324
+        for more information.
+#>
+function Get-ActiveDirectoryDomain
+{
+    [CmdletBinding()]
+    [OutputType([System.DirectoryServices.ActiveDirectory.Domain])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.DirectoryServices.ActiveDirectory.DirectoryContext]
+        $DirectoryContext
+    )
+
+    return [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($DirectoryContext)
+}
+
+<#
+    .SYNOPSIS
+        This returns a new object of the type System.DirectoryServices.ActiveDirectory.Forest
+        which is a class that represents an Active Directory Domain Services forest.
+
+    .PARAMETER DirectoryContext
+        The Active Directory context from which the forest object is returned.
+        Calling the Get-ADDirectoryContext gets a value that can be provided in
+        this parameter.
+
+    .NOTES
+        This is a wrapper to enable unit testing of this resource.
+        see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/324
+        for more information.
+#>
+function Get-ActiveDirectoryForest
+{
+    [CmdletBinding()]
+    [OutputType([System.DirectoryServices.ActiveDirectory.Forest])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.DirectoryServices.ActiveDirectory.DirectoryContext]
+        $DirectoryContext
+    )
+
+    return [System.DirectoryServices.ActiveDirectory.Forest]::GetForest($DirectoryContext)
+}


### PR DESCRIPTION
#### Pull Request (PR) description

This PR moves the `Get-ActiveDirectoryDomain` and `Get-ActiveDirectoryForest` functions in the `ADDomainTrust` resource into the `ActiveDirectoryDsc.Common` module.

This increases the Code Coverage of the `ADDomainTrust` resource to 100%.

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/602)
<!-- Reviewable:end -->
