### PR TITLE
ADReplicationSiteLink: Fix Setting Options After the Resource is Initially Created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Move `Get-ActiveDirectoryDomain` and `Get-ActiveDirectoryForest` functions
     into the `ActiveDirectoryDsc.Common` module.
 
+### Fixed
+
+- ADReplicationSiteLink
+  - Fixed setting options after the resource is initially created
+    ([issue #605](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/605)).
+
 ## [6.0.1] - 2020-04-16
 
 ### Fixed

--- a/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
+++ b/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
@@ -193,8 +193,8 @@ function Set-TargetResource
         $currentADSiteLink = Get-TargetResource -Name $Name
 
         <#
-            Since Set and New have different parameters we have to test if the
-            site link exists to determine what cmdlet we need to use.
+            Since Set and New have different parameters we have to test if the site link exists to determine what
+            cmdlet we need to use.
         #>
         if ( $currentADSiteLink.Ensure -eq 'Absent' )
         {

--- a/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
+++ b/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
@@ -171,15 +171,15 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $OptionChangeNotification = $false,
+        $OptionChangeNotification,
 
         [Parameter()]
         [System.Boolean]
-        $OptionTwoWaySync = $false,
+        $OptionTwoWaySync,
 
         [Parameter()]
         [System.Boolean]
-        $OptionDisableCompression = $false,
+        $OptionDisableCompression,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -201,7 +201,7 @@ function Set-TargetResource
             # Resource is Absent
 
             # Modify parameters for splatting to New-ADReplicationSiteLink.
-            $newADReplicationSiteLinkParameters = @{ } + $PSBoundParameters
+            $newADReplicationSiteLinkParameters = @{} + $PSBoundParameters
             $newADReplicationSiteLinkParameters.Remove('Ensure')
             $newADReplicationSiteLinkParameters.Remove('SitesExcluded')
             $newADReplicationSiteLinkParameters.Remove('OptionChangeNotification')
@@ -226,17 +226,17 @@ function Set-TargetResource
         {
             # Resource is Present
 
-            $setADReplicationSiteLinkParameters = @{ }
+            $setADReplicationSiteLinkParameters = @{}
             $setADReplicationSiteLinkParameters['Identity'] = $Name
 
-            $replaceParameters = @{ }
+            $replaceParameters = @{}
 
             # now we have to determine if we need to add or remove sites from SitesIncluded.
             if (-not (Test-Members -ExistingMembers $currentADSiteLink.SitesIncluded `
                         -MembersToInclude $SitesIncluded -MembersToExclude $SitesExcluded))
             {
                 # build the SitesIncluded hashtable.
-                $sitesIncludedParameters = @{ }
+                $sitesIncludedParameters = @{}
                 if ($SitesExcluded)
                 {
                     Write-Verbose -Message ($script:localizedData.RemovingSites -f $($SitesExcluded -join ', '), $Name)
@@ -265,31 +265,30 @@ function Set-TargetResource
                 }
             }
 
-            if ($PSBoundParameters.ContainsKey('Cost') -and `
-                    $Cost -ne $currentADSiteLink.Cost)
+            if ($PSBoundParameters.ContainsKey('Cost') -and $Cost -ne $currentADSiteLink.Cost)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
                     'Cost', $Cost, $Name)
                 $setADReplicationSiteLinkParameters['Cost'] = $Cost
             }
 
-            if ($PSBoundParameters.ContainsKey('Description') -and `
-                    $Description -ne $currentADSiteLink.Description)
+            if ($PSBoundParameters.ContainsKey('Description') -and $Description -ne $currentADSiteLink.Description)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
                     'Description', $Description, $Name)
                 $setADReplicationSiteLinkParameters['Description'] = $Description
             }
 
-            if ($PSBoundParameters.ContainsKey('ReplicationFrequencyInMinutes') -and `
-                    $ReplicationFrequencyInMinutes -ne $currentADSiteLink.ReplicationFrequencyInMinutes)
+            if ($PSBoundParameters.ContainsKey('ReplicationFrequencyInMinutes') -and
+                $ReplicationFrequencyInMinutes -ne $currentADSiteLink.ReplicationFrequencyInMinutes)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
                     'ReplicationFrequencyInMinutes', $ReplicationFrequencyInMinutes, $Name)
                 $setADReplicationSiteLinkParameters['ReplicationFrequencyInMinutes'] = $ReplicationFrequencyInMinutes
             }
 
-            if ($OptionChangeNotification -ne $currentADSiteLink.OptionChangeNotification)
+            if ($PSBoundParameters.ContainsKey('ReplicationFrequencyInMinutes') -and
+                $OptionChangeNotification -ne $currentADSiteLink.OptionChangeNotification)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
                     'OptionChangeNotification', $OptionChangeNotification, $Name)
@@ -300,7 +299,8 @@ function Set-TargetResource
                 $desiredChangeNotification = $currentADSiteLink.OptionChangeNotification
             }
 
-            if ($OptionTwoWaySync -ne $currentADSiteLink.OptionTwoWaySync)
+            if ($PSBoundParameters.ContainsKey('ReplicationFrequencyInMinutes') -and
+                $OptionTwoWaySync -ne $currentADSiteLink.OptionTwoWaySync)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
                     'TwoWaySync', $OptionTwoWaySync, $Name)
@@ -311,7 +311,8 @@ function Set-TargetResource
                 $desiredTwoWaySync = $currentADSiteLink.OptionTwoWaySync
             }
 
-            if ($OptionDisableCompression -ne $currentADSiteLink.OptionDisableCompression)
+            if ($PSBoundParameters.ContainsKey('ReplicationFrequencyInMinutes') -and
+                $OptionDisableCompression -ne $currentADSiteLink.OptionDisableCompression)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
                     'OptionDisableCompression', $OptionDisableCompression, $Name)
@@ -427,15 +428,15 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $OptionChangeNotification = $false,
+        $OptionChangeNotification,
 
         [Parameter()]
         [System.Boolean]
-        $OptionTwoWaySync = $false,
+        $OptionTwoWaySync,
 
         [Parameter()]
         [System.Boolean]
-        $OptionDisableCompression = $false,
+        $OptionDisableCompression,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]

--- a/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
+++ b/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
@@ -289,52 +289,58 @@ function Set-TargetResource
                 $setADReplicationSiteLinkParameters['ReplicationFrequencyInMinutes'] = $ReplicationFrequencyInMinutes
             }
 
-            if ($PSBoundParameters.ContainsKey('OptionChangeNotification') -and `
-                    $OptionChangeNotification -ne $currentADSiteLink.OptionChangeNotification)
+            if ($OptionChangeNotification -ne $currentADSiteLink.OptionChangeNotification)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
                     'OptionChangeNotification', $OptionChangeNotification, $Name)
-                $changeNotification = $OptionChangeNotification
+                $desiredChangeNotification = $OptionChangeNotification
             }
             else
             {
-                $changeNotification = $currentADSiteLink.OptionChangeNotification
+                $desiredChangeNotification = $currentADSiteLink.OptionChangeNotification
             }
 
-            if ($PSBoundParameters.ContainsKey('OptionTwoWaySync') -and `
-                    $OptionTwoWaySync -ne $currentADSiteLink.OptionTwoWaySync)
+            if ($OptionTwoWaySync -ne $currentADSiteLink.OptionTwoWaySync)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
                     'TwoWaySync', $OptionTwoWaySync, $Name)
-                $twoWaySync = $OptionTwoWaySync
+                $desiredTwoWaySync = $OptionTwoWaySync
             }
             else
             {
-                $twoWaySync = $currentADSiteLink.OptionTwoWaySync
+                $desiredTwoWaySync = $currentADSiteLink.OptionTwoWaySync
             }
 
-            if ($PSBoundParameters.ContainsKey('OptionDisableCompression') -and `
-                    $OptionDisableCompression -ne $currentADSiteLink.OptionDisableCompression)
+            if ($OptionDisableCompression -ne $currentADSiteLink.OptionDisableCompression)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
                     'OptionDisableCompression', $OptionDisableCompression, $Name)
-                $disableCompression = $OptionDisableCompression
+                $desiredDisableCompression = $OptionDisableCompression
             }
             else
             {
-                $disableCompression = $currentADSiteLink.OptionDisableCompression
+                $desiredDisableCompression = $currentADSiteLink.OptionDisableCompression
             }
 
-            $optionsValue = ConvertTo-EnabledOptions -OptionChangeNotification $changeNotification `
-                -OptionTwoWaySync $twoWaySync -OptionDisableCompression $disableCompression
+            $currentOptionsValue = ConvertTo-EnabledOptions `
+                -OptionChangeNotification $currentADSiteLink.OptionChangeNotification `
+                -OptionTwoWaySync $currentADSiteLink.OptionTwoWaySync `
+                -OptionDisableCompression $currentADSiteLink.OptionDisableCompression
+            $desiredOptionsValue = ConvertTo-EnabledOptions `
+                -OptionChangeNotification $desiredChangeNotification `
+                -OptionTwoWaySync $desiredTwoWaySync `
+                -OptionDisableCompression $desiredDisableCompression
 
-            if ($optionsValue -gt 0)
+            if ($currentOptionsValue -ne $desiredOptionsValue)
             {
-                $setADReplicationSiteLinkParameters.Add('Clear', 'Options')
-            }
-            else
-            {
-                $replaceParameters.Add('Options', $optionsValue)
+                if ($desiredoptionsValue -eq 0)
+                {
+                    $setADReplicationSiteLinkParameters.Add('Clear', 'Options')
+                }
+                else
+                {
+                    $replaceParameters.Add('Options', $desiredOptionsValue)
+                }
             }
 
             if ($replaceParameters.Count -gt 0)

--- a/tests/Unit/MSFT_ADReplicationSiteLink.tests.ps1
+++ b/tests/Unit/MSFT_ADReplicationSiteLink.tests.ps1
@@ -58,8 +58,8 @@ try
             Cost                          = 1
             Description                   = 'My Changed Description'
             ReplicationFrequencyInMinutes = 1
-            SitesIncluded                 = 'site11', 'site12'
-            SitesExcluded                 = $mockResource.SitesIncluded
+            SitesIncluded                 = $mockSite3
+            SitesExcluded                 = $mockSite1
             OptionChangeNotification      = $true
             OptionTwoWaySync              = $true
             OptionDisableCompression      = $true
@@ -335,9 +335,6 @@ try
                 }
 
                 Context 'When the Resource should be Present' {
-                    BeforeAll {
-
-                    }
 
                     foreach ($property in $mockChangedResource.Keys)
                     {
@@ -345,9 +342,39 @@ try
                             BeforeAll {
                                 $setTargetResourceParametersChangedProperty = $setTargetResourcePresentParameters.Clone()
                                 $setTargetResourceParametersChangedProperty.$property = $mockChangedResource.$property
-                                if ($property -eq 'SitesExcluded')
+
+                                if ($property -eq 'Cost')
+                                {
+                                    $setParameterFilter = { $Cost -eq $setTargetResourceParametersChangedProperty.Cost }
+                                }
+                                elseif ($property -eq 'Description')
+                                {
+                                    $setParameterFilter = { $Description -eq $setTargetResourceParametersChangedProperty.Description }
+                                }
+                                elseif ($property -eq 'ReplicationFrequencyInMinutes')
+                                {
+                                    $setParameterFilter = { $ReplicationFrequencyInMinutes -eq $setTargetResourceParametersChangedProperty.ReplicationFrequencyInMinutes }
+                                }
+                                elseif ($property -eq 'SitesIncluded')
+                                {
+                                    $setParameterFilter = { $SitesIncluded.Add -eq $setTargetResourceParametersChangedProperty.SitesIncluded }
+                                }
+                                elseif ($property -eq 'SitesExcluded')
                                 {
                                     $setTargetResourceParametersChangedProperty['SitesIncluded'] = ''
+                                    $setParameterFilter = { $SitesIncluded.Remove -eq $setTargetResourceParametersChangedProperty.SitesExcluded }
+                                }
+                                elseif ($property -eq 'OptionChangeNotification')
+                                {
+                                    $setParameterFilter = { $Replace.Options -eq 1 }
+                                }
+                                elseif ($property -eq 'OptionTwoWaySync')
+                                {
+                                    $setParameterFilter = { $Replace.Options -eq 2 }
+                                }
+                                elseif ($property -eq 'OptionDisableCompression')
+                                {
+                                    $setParameterFilter = { $Replace.Options -eq 4 }
                                 }
                             }
 
@@ -361,7 +388,7 @@ try
                                         $Name -eq $setTargetResourceParametersChangedProperty.Name } `
                                     -Exactly -Times 1
                                 Assert-MockCalled -CommandName Set-ADReplicationSiteLink `
-                                    -ParameterFilter { $PSBoundParameters.Keys.Count -eq 2 } `
+                                    -ParameterFilter $setParameterFilter `
                                     -Exactly -Times 1
                                 Assert-MockCalled -CommandName New-ADReplicationSiteLink  `
                                     -Exactly -Times 0

--- a/tests/Unit/MSFT_ADReplicationSiteLink.tests.ps1
+++ b/tests/Unit/MSFT_ADReplicationSiteLink.tests.ps1
@@ -360,6 +360,11 @@ try
                                     -ParameterFilter { `
                                         $Name -eq $setTargetResourceParametersChangedProperty.Name } `
                                     -Exactly -Times 1
+                                Assert-MockCalled -CommandName Set-ADReplicationSiteLink `
+                                    -ParameterFilter { $PSBoundParameters.Keys.Count -eq 2 } `
+                                    -Exactly -Times 1
+                                Assert-MockCalled -CommandName New-ADReplicationSiteLink  `
+                                    -Exactly -Times 0
                             }
                         }
                     }

--- a/tests/Unit/MSFT_ADReplicationSiteLink.tests.ps1
+++ b/tests/Unit/MSFT_ADReplicationSiteLink.tests.ps1
@@ -340,29 +340,35 @@ try
                     {
                         Context "When $property has changed" {
                             BeforeAll {
-                                $setTargetResourceParametersChangedProperty = $setTargetResourcePresentParameters.Clone()
+                                $setTargetResourceParametersChangedProperty = `
+                                    $setTargetResourcePresentParameters.Clone()
                                 $setTargetResourceParametersChangedProperty.$property = $mockChangedResource.$property
 
                                 if ($property -eq 'Cost')
                                 {
-                                    $setParameterFilter = { $Cost -eq $setTargetResourceParametersChangedProperty.Cost }
+                                    $setParameterFilter = `
+                                    { $Cost -eq $setTargetResourceParametersChangedProperty.Cost }
                                 }
                                 elseif ($property -eq 'Description')
                                 {
-                                    $setParameterFilter = { $Description -eq $setTargetResourceParametersChangedProperty.Description }
+                                    $setParameterFilter = { $Description -eq
+                                        $setTargetResourceParametersChangedProperty.Description }
                                 }
                                 elseif ($property -eq 'ReplicationFrequencyInMinutes')
                                 {
-                                    $setParameterFilter = { $ReplicationFrequencyInMinutes -eq $setTargetResourceParametersChangedProperty.ReplicationFrequencyInMinutes }
+                                    $setParameterFilter = { $ReplicationFrequencyInMinutes -eq
+                                        $setTargetResourceParametersChangedProperty.ReplicationFrequencyInMinutes }
                                 }
                                 elseif ($property -eq 'SitesIncluded')
                                 {
-                                    $setParameterFilter = { $SitesIncluded.Add -eq $setTargetResourceParametersChangedProperty.SitesIncluded }
+                                    $setParameterFilter = { $SitesIncluded.Add -eq
+                                        $setTargetResourceParametersChangedProperty.SitesIncluded }
                                 }
                                 elseif ($property -eq 'SitesExcluded')
                                 {
                                     $setTargetResourceParametersChangedProperty['SitesIncluded'] = ''
-                                    $setParameterFilter = { $SitesIncluded.Remove -eq $setTargetResourceParametersChangedProperty.SitesExcluded }
+                                    $setParameterFilter = { $SitesIncluded.Remove -eq
+                                        $setTargetResourceParametersChangedProperty.SitesExcluded }
                                 }
                                 elseif ($property -eq 'OptionChangeNotification')
                                 {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the issue with the `ADReplicationSiteLink` resource whereby setting `OptionChangeNotification`, `OptionTwoWaySync` or `OptionDisableCompression` fails after the resource is initially created.

#### This Pull Request (PR) fixes the following issues

- Fixes #605

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/606)
<!-- Reviewable:end -->
