### PR TITLE
ADDomainController: Fix Test-TargetResource Issue When the 'ReadOnlyReplica' Property is set to 'true'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Restored importing the `DscResource.Common` module import in the `ActiveDirectoryDsc.Common` module that was
     incorrectly disabled.
     ([issue #612](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/612)).
+- ADDomainController
+  - Fixed `Test-TargetResource` error when the `ReadOnlyReplica` property is set to `true`
+    ([issue #611](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/611)).
 - ADReplicationSiteLink
   - Fixed setting options after the resource is initially created
     ([issue #605](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/605)).

--- a/source/DSCResources/MSFT_ADDomainController/MSFT_ADDomainController.psm1
+++ b/source/DSCResources/MSFT_ADDomainController/MSFT_ADDomainController.psm1
@@ -709,7 +709,7 @@ function Test-TargetResource
 
     if ($PSBoundParameters.ContainsKey('ReadOnlyReplica') -and $ReadOnlyReplica)
     {
-        if ($testTargetResourceReturnValue -and -not $testTargetResourceReturnValue.ReadOnlyReplica)
+        if ($testTargetResourceReturnValue -and -not $existingResource.ReadOnlyReplica)
         {
             New-InvalidOperationException -Message $script:localizedData.CannotConvertToRODC
         }

--- a/tests/Unit/MSFT_ADDomainController.Tests.ps1
+++ b/tests/Unit/MSFT_ADDomainController.Tests.ps1
@@ -370,6 +370,7 @@ try
                             AllowPasswordReplicationAccountName = @($allowedAccount)
                             DenyPasswordReplicationAccountName  = @($deniedAccount)
                             FlexibleSingleMasterOperationRole   = @('DomainNamingMaster', 'RIDMaster')
+                            ReadOnlyReplica                     = $true
                             Ensure                              = $true
                         }
                     }
@@ -445,6 +446,18 @@ try
                     It 'Should return $true' {
                         $result = Test-TargetResource @testDefaultParams -DomainName $correctDomainName `
                             -FlexibleSingleMasterOperationRole @('RIDMaster')
+                        $result | Should -Be $true
+                    }
+
+                    It 'Should call the expected mocks' {
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1
+                    }
+                }
+
+                Context 'When property ReadOnlyReplica and SiteName are in desired state' {
+                    It 'Should return $true' {
+                        $result = Test-TargetResource @testDefaultParams -DomainName $correctDomainName `
+                            -ReadOnlyReplica $true -SiteName $correctSiteName
                         $result | Should -Be $true
                     }
 


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes an issue with the `ADDomainController` resource whereby the `Test-TargetResource` function will raise an error if the `ReadOnlyReplica` property is set to `true`.

#### This Pull Request (PR) fixes the following issues

- Fixes #611 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/615)
<!-- Reviewable:end -->
