### PR TITLE
ADGroup, ADUser: add SamAccountName property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - ADGroup
   - Refactored Module.
   - Refactored Unit and Integration Tests.
+- ADGroup, ADUser, ADManagedServiceAccount
+  - Allow settings sAMAccountName independently.
 
 ### Added
 

--- a/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.psm1
+++ b/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.psm1
@@ -71,7 +71,7 @@ function Get-TargetResource
 
     Write-Verbose -Message ($script:localizedData.RetrievingGroup -f $GroupName)
 
-    $getADGroupProperties = ('Name', 'GroupScope', 'GroupCategory', 'DistinguishedName', 'Description', 'DisplayName',
+    $getADGroupProperties = ('Name', 'GroupScope', 'GroupCategory', 'DistinguishedName', 'Description', 'DisplayName', 'SamAccountName',
         'ManagedBy', 'Members', 'Info')
 
     try
@@ -163,6 +163,7 @@ function Get-TargetResource
             Path                = Get-ADObjectParentDN -DN $adGroup.DistinguishedName
             Description         = $adGroup.Description
             DisplayName         = $adGroup.DisplayName
+            SamAccountName      = $adGroup.SamAccountName
             Members             = $adGroupMembers
             MembersToInclude    = $null
             MembersToExclude    = $null
@@ -184,6 +185,7 @@ function Get-TargetResource
             Path                = $null
             Description         = $null
             DisplayName         = $null
+            SamAccountName      = $null
             Members             = @()
             MembersToInclude    = $null
             MembersToExclude    = $null
@@ -221,6 +223,9 @@ function Get-TargetResource
 
     .PARAMETER DisplayName
         Display name of the Active Directory group.
+
+    .PARAMETER SamAccountName
+        SamAccountName of the Active Directory group.
 
     .PARAMETER Credential
         The credential to be used to perform the operation on Active Directory.
@@ -298,6 +303,11 @@ function Test-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -474,6 +484,9 @@ function Test-TargetResource
     .PARAMETER DisplayName
         Display name of the Active Directory group.
 
+    .PARAMETER SamAccountName
+        SamAccountName of the Active Directory group.
+
     .PARAMETER Credential
         The credential to be used to perform the operation on Active Directory.
 
@@ -557,6 +570,11 @@ function Set-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -904,6 +922,11 @@ function Set-TargetResource
             if ($PSBoundParameters.ContainsKey('DisplayName'))
             {
                 $newAdGroupParameters['DisplayName'] = $DisplayName
+            }
+
+            if ($PSBoundParameters.ContainsKey('SamAccountName'))
+            {
+                $newAdGroupParameters['SamAccountName'] = $SamAccountName
             }
 
             if ($PSBoundParameters.ContainsKey('ManagedBy'))

--- a/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.schema.mof
+++ b/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.schema.mof
@@ -8,6 +8,7 @@ class MSFT_ADGroup : OMI_BaseResource
     [Write, Description("Specifies if this Active Directory group should be present or absent. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Description of the Active Directory group.")] String Description;
     [Write, Description("Display name of the Active Directory group.")] String DisplayName;
+    [Write, Description("SamAccountName of the Active Directory group.")] String SamAccountName;
     [Write, Description("The credential to be used to perform the operation on Active Directory."), EmbeddedInstance("MSFT_Credential")] String Credential;
     [Write, Description("Active Directory domain controller to enact the change upon.")] String DomainController;
     [Write, Description("Active Directory group membership should match membership exactly.")] String Members[];

--- a/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
+++ b/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
@@ -16,9 +16,7 @@ $script:errorCodeKdsRootKeyNotFound = -2146893811
         Returns the current state of an Active Directory managed service account.
 
     .PARAMETER ServiceAccountName
-    Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
-    'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20 characters
-    or less. Once created, the user's SamAccountName and CN cannot be changed.
+        Specifies the name of the object. This parameter sets the Name property of the Active Directory object. The LDAP Display Name (ldapDisplayName) of this property is 'name'. Once created, the account's Name cannot be changed. Once created, the user's SamAccountName and CN cannot be changed.
 
     .PARAMETER AccountType
         The type of managed service account. Standalone will create a Standalone Managed Service Account (sMSA) and
@@ -92,6 +90,7 @@ function Get-TargetResource
             'DistinguishedName'
             'Description'
             'DisplayName'
+            'SamAccountName'
             'ObjectClass'
             'Enabled'
             'PrincipalsAllowedToRetrieveManagedPassword'
@@ -154,6 +153,7 @@ function Get-TargetResource
             Path                      = Get-ADObjectParentDN -DN $adServiceAccount.DistinguishedName
             Description               = $adServiceAccount.Description
             DisplayName               = $adServiceAccount.DisplayName
+            SamAccountName            = $SamAccountName
             DistinguishedName         = $adServiceAccount.DistinguishedName
             Enabled                   = $adServiceAccount.Enabled
             KerberosEncryptionType    = $adServiceAccount.KerberosEncryptionType -split (', ')
@@ -171,6 +171,7 @@ function Get-TargetResource
             Path                      = $null
             Description               = $null
             DisplayName               = $null
+            SamAccountName            = $null
             DistinguishedName         = $null
             Enabled                   = $false
             KerberosEncryptionType    = @()
@@ -188,9 +189,7 @@ function Get-TargetResource
         Tests if an Active Directory managed service account is in the desired state.
 
     .PARAMETER ServiceAccountName
-        Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
-        'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20
-        characters or less. Once created, the user's SamAccountName and CN cannot be changed.
+        Specifies the name of the object. This parameter sets the Name property of the Active Directory object. The LDAP Display Name (ldapDisplayName) of this property is 'name'. Once created, the account's Name cannot be changed. Once created, the user's SamAccountName and CN cannot be changed.
 
     .PARAMETER AccountType
         The type of managed service account. Standalone will create a Standalone Managed Service Account (sMSA) and
@@ -205,6 +204,11 @@ function Get-TargetResource
 
     .PARAMETER DisplayName
         Specifies the display name of the account (ldapDisplayName 'displayName').
+
+    .PARAMETER SamAccountName
+        Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
+        'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20
+        characters or less.
 
     .PARAMETER DomainController
         Specifies the Active Directory Domain Controller instance to use to perform the task.
@@ -267,6 +271,11 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -375,9 +384,7 @@ function Test-TargetResource
         Sets the state of an Active Directory managed service account.
 
     .PARAMETER ServiceAccountName
-        Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
-        'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20
-        characters or less. Once created, the user's SamAccountName and CN cannot be changed.
+        Specifies the name of the object. This parameter sets the Name property of the Active Directory object. The LDAP Display Name (ldapDisplayName) of this property is 'name'. Once created, the account's Name cannot be changed. Once created, the user's SamAccountName and CN cannot be changed.
 
     .PARAMETER AccountType
         The type of managed service account. Standalone will create a Standalone Managed Service Account (sMSA) and
@@ -392,6 +399,11 @@ function Test-TargetResource
 
     .PARAMETER DisplayName
         Specifies the display name of the account (ldapDisplayName 'displayName').
+
+    .PARAMETER SamAccountName
+        Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
+        'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20
+        characters or less.
 
     .PARAMETER DomainController
         Specifies the Active Directory Domain Controller instance to use to perform the task.
@@ -462,6 +474,11 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
+++ b/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
@@ -153,7 +153,7 @@ function Get-TargetResource
             Path                      = Get-ADObjectParentDN -DN $adServiceAccount.DistinguishedName
             Description               = $adServiceAccount.Description
             DisplayName               = $adServiceAccount.DisplayName
-            SamAccountName            = $SamAccountName
+            SamAccountName            = $adServiceAccount.SamAccountName
             DistinguishedName         = $adServiceAccount.DistinguishedName
             Enabled                   = $adServiceAccount.Enabled
             KerberosEncryptionType    = $adServiceAccount.KerberosEncryptionType -split (', ')

--- a/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.schema.mof
+++ b/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.schema.mof
@@ -1,11 +1,12 @@
 [ClassVersion("1.0.1.0"), FriendlyName("ADManagedServiceAccount")]
 class MSFT_ADManagedServiceAccount : OMI_BaseResource
 {
-    [Key, Description("Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName 'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20 characters or less. Once created, the user's SamAccountName and CN cannot be changed.")] String ServiceAccountName;
+    [Key, Description("Specifies the name of the object. This parameter sets the Name property of the Active Directory object. The LDAP Display Name (ldapDisplayName) of this property is 'name'. Once created, the account's Name cannot be changed.")] String ServiceAccountName;
     [Required, Description("The type of managed service account. Standalone will create a Standalone Managed Service Account (sMSA) and Group will create a Group Managed Service Account (gMSA)."), ValueMap{"Group","Standalone"}, Values{"Group","Standalone"}] String AccountType;
     [Write, Description("Specifies the user account credentials to use to perform this task. This is only required if not executing the task on a domain controller or using the parameter DomainController."), EmbeddedInstance("MSFT_Credential")] String Credential;
     [Write, Description("Specifies the description of the account (ldapDisplayName 'description').")] String Description;
     [Write, Description("Specifies the display name of the account (ldapDisplayName 'displayName').")] String DisplayName;
+    [Write, Description("Specifies the Security Account Manager (SAM) account name of the service account. To be compatible with older operating systems, create a SAM account name that is 20 characters or less. If the string value provided is not terminated with a '$' character, the system adds one if needed. The LDAP display name (ldapDisplayName) for this property is 'sAMAccountName'.")] String SamAccountName;
     [Write, Description("Specifies the Active Directory Domain Controller instance to use to perform the task. This is only required if not executing the task on a domain controller.")] String DomainController;
     [Write, Description("Specifies whether the user account is created or deleted. If not specified, this value defaults to Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Specifies which Kerberos encryption types the account supports when creating service tickets. This value sets the encryption types supported flags of the Active Directory msDS-SupportedEncryptionTypes attribute."),ValueMap{"None","RC4","AES128","AES256"}, Values{"None","RC4","AES128","AES256"}] String KerberosEncryptionType[];

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.PropertyMap.psd1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.PropertyMap.psd1
@@ -19,6 +19,12 @@
             Array              = $false
         }
         @{
+            Parameter          = 'SamAccountName'
+            ADProperty         = 'SamAccountName'
+            UseCmdletParameter = $true
+            Array              = $false
+        }
+        @{
             Parameter          = 'Path'
             ADProperty         = 'distinguishedName'
             UseCmdletParameter = $true

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -187,7 +187,7 @@ function Get-TargetResource
 
     .PARAMETER UserName
         Specifies the account name of the user. (You can identify a user by its distinguished
-    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
+    name (DN), GUID, security identifier (SID), or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER Password
         Specifies a new password value for the account.
@@ -204,6 +204,9 @@ function Get-TargetResource
 
     .PARAMETER DisplayName
         Specifies the display name of the object (ldapDisplayName 'displayName').
+
+    .PARAMETER SamAccountName
+        Specifies the SamAccountName of the object (ldapDisplayName 'SamAccountName').
 
     .PARAMETER Path
         Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created.
@@ -305,7 +308,7 @@ function Get-TargetResource
     .PARAMETER LogonWorkstations
         Specifies the computers that the user can access. To specify more than one computer, create a single
         comma-separated list. You can identify a computer by using the Security Account Manager (SAM) account name
-        (sAMAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of
+        (SamAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of
         the computer (ldapDisplayName 'userWorkStations').
 
     .PARAMETER Organization
@@ -433,6 +436,11 @@ function Test-TargetResource
         [ValidateNotNull()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -872,7 +880,7 @@ function Test-TargetResource
 
     .PARAMETER UserName
         Specifies the account name of the user. (You can identify a user by its distinguished
-    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
+    name (DN), GUID, security identifier (SID), or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER Password
         Specifies a new password value for the account.
@@ -889,6 +897,9 @@ function Test-TargetResource
 
     .PARAMETER DisplayName
         Specifies the display name of the object (ldapDisplayName 'displayName').
+
+    .PARAMETER SamAccountName
+        Specifies the SamAccountName of the object (ldapDisplayName 'SamAccountName').
 
     .PARAMETER Path
         Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created.
@@ -990,7 +1001,7 @@ function Test-TargetResource
     .PARAMETER LogonWorkstations
         Specifies the computers that the user can access. To specify more than one computer, create a single
         comma-separated list. You can identify a computer by using the Security Account Manager (SAM) account name
-        (sAMAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of
+        (SamAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of
         the computer (ldapDisplayName 'userWorkStations').
 
     .PARAMETER Organization
@@ -1127,6 +1138,11 @@ function Set-TargetResource
         [ValidateNotNull()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNull()]

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -27,7 +27,8 @@ $adPropertyMap = (Import-PowerShellDataFile -Path $adPropertyMapPath).Parameters
         Name of the domain where the user account is located (only used if password is managed).
 
     .PARAMETER UserName
-        Specifies the Security Account Manager (SAM) account name of the user (ldapDisplayName 'sAMAccountName').
+        Specifies the account name of the user. (You can identify a user by its distinguished
+    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER DomainController
         Specifies the Active Directory Domain Services instance to use to perform the task.
@@ -185,7 +186,8 @@ function Get-TargetResource
         Name of the domain where the user account is located (only used if password is managed).
 
     .PARAMETER UserName
-        Specifies the Security Account Manager (SAM) account name of the user (ldapDisplayName 'sAMAccountName').
+        Specifies the account name of the user. (You can identify a user by its distinguished
+    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER Password
         Specifies a new password value for the account.
@@ -869,7 +871,8 @@ function Test-TargetResource
         Name of the domain where the user account is located (only used if password is managed).
 
     .PARAMETER UserName
-        Specifies the Security Account Manager (SAM) account name of the user (ldapDisplayName 'sAMAccountName').
+        Specifies the account name of the user. (You can identify a user by its distinguished
+    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER Password
         Specifies a new password value for the account.
@@ -1506,7 +1509,7 @@ function Set-TargetResource
 
                 Write-Debug -Message ('New-ADUser Parameters:' + ($newADUserParams | Out-String))
 
-                $newADUser = New-ADUser @newADUserParams -SamAccountName $UserName -Passthru
+                $newADUser = New-ADUser @newADUserParams -Name $UserName -Passthru
 
                 if ($updateCnRequired)
                 {

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
@@ -2,7 +2,8 @@
 class MSFT_ADUser : OMI_BaseResource
 {
     [Key, Description("Name of the domain where the user account is located (only used if password is managed).")] String DomainName;
-    [Key, Description("Specifies the Security Account Manager (SAM) account name of the user (ldapDisplayName 'sAMAccountName').")] String UserName;
+    [Key, Description("Specifies the account name of the user. (You can identify a user by its distinguished
+    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)")] String UserName;
     [Write, Description("Specifies a new password value for the account."), EmbeddedInstance("MSFT_Credential")] String Password;
     [Write, Description("Specifies whether the user account should be present or absent. Default value is 'Present'."), ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
     [Write, Description("Specifies the common name assigned to the user account (ldapDisplayName 'cn'). If not specified the default value will be the same value provided in parameter UserName.")] String CommonName;

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
@@ -2,13 +2,13 @@
 class MSFT_ADUser : OMI_BaseResource
 {
     [Key, Description("Name of the domain where the user account is located (only used if password is managed).")] String DomainName;
-    [Key, Description("Specifies the account name of the user. (You can identify a user by its distinguished
-    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)")] String UserName;
+    [Key, Description("Specifies the account name of the user. (You can identify a user by its distinguished name (DN), GUID, security identifier (SID), or Security Accounts Manager (SAM) account name.)")] String UserName;
     [Write, Description("Specifies a new password value for the account."), EmbeddedInstance("MSFT_Credential")] String Password;
     [Write, Description("Specifies whether the user account should be present or absent. Default value is 'Present'."), ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
     [Write, Description("Specifies the common name assigned to the user account (ldapDisplayName 'cn'). If not specified the default value will be the same value provided in parameter UserName.")] String CommonName;
     [Write, Description("Specifies the User Principal Name (UPN) assigned to the user account (ldapDisplayName 'userPrincipalName').")] String UserPrincipalName;
     [Write, Description("Specifies the display name of the object (ldapDisplayName 'displayName').")] String DisplayName;
+    [Write, Description("Specifies the SamAccountName of the object (ldapDisplayName 'SamAccountName').")] String SamAccountName;
     [Write, Description("Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created.")] String Path;
     [Write, Description("Specifies the user's given name (ldapDisplayName 'givenName').")] String GivenName;
     [Write, Description("Specifies the initials that represent part of a user's name (ldapDisplayName 'initials').")] String Initials;
@@ -41,7 +41,7 @@ class MSFT_ADUser : OMI_BaseResource
     [Write, Description("Specifies the user's pager number (ldapDisplayName 'pager').")] String Pager;
     [Write, Description("Specifies the user's IP telephony phone number (ldapDisplayName 'ipPhone').")] String IPPhone;
     [Write, Description("Specifies the user's manager specified as a Distinguished Name (ldapDisplayName 'manager').")] String Manager;
-    [Write, Description("Specifies the computers that the user can access. To specify more than one computer, create a single comma-separated list. You can identify a computer by using the Security Account Manager (SAM) account name (sAMAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of the computer. The LDAP display name (ldapDisplayName) for this property is userWorkStations.")] String LogonWorkstations;
+    [Write, Description("Specifies the computers that the user can access. To specify more than one computer, create a single comma-separated list. You can identify a computer by using the Security Account Manager (SAM) account name (SamAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of the computer. The LDAP display name (ldapDisplayName) for this property is userWorkStations.")] String LogonWorkstations;
     [Write, Description("Specifies the user's organization. This parameter sets the Organization property of a user object. The LDAP display name (ldapDisplayName) of this property is 'o'.")] String Organization;
     [Write, Description("Specifies a name in addition to a user's given name and surname, such as the user's middle name. This parameter sets the OtherName property of a user object. The LDAP display name (ldapDisplayName) of this property is 'middleName'.")] String OtherName;
     [Write, Description("Specifies if the account is enabled. Default value is $true.")] Boolean Enabled;

--- a/tests/Unit/MSFT_ADGroup.Tests.ps1
+++ b/tests/Unit/MSFT_ADGroup.Tests.ps1
@@ -43,6 +43,7 @@ try
             Path        = 'OU=OU,DC=contoso,DC=com'
             Description = 'Test AD group description'
             DisplayName = 'Test display name'
+            SamAccountName = 'TestGroup'
             Ensure      = 'Present'
             Notes       = 'This is a test AD group'
             ManagedBy   = 'CN=User 1,CN=Users,DC=contoso,DC=com'
@@ -91,6 +92,7 @@ try
             Path              = $mockGroupPath
             Description       = 'Test AD group description'
             DisplayName       = 'Test display name'
+            SamAccountName    = $mockGroupName
             Info              = 'This is a test AD group'
             ManagedBy         = 'CN=User 1,CN=Users,DC=contoso,DC=com'
             DistinguishedName = "CN=$mockGroupName,$mockGroupPath"
@@ -101,6 +103,7 @@ try
             GroupScope  = 'Universal'
             Description = 'Test AD group description changed'
             DisplayName = 'Test display name changed'
+            SamAccountName = 'TestGroup2'
             ManagedBy   = 'CN=User 2,CN=Users,DC=contoso,DC=com'
         }
 
@@ -111,6 +114,7 @@ try
             Path              = $mockADGroup.Path
             Description       = $mockADGroup.Description
             DisplayName       = $mockADGroup.DisplayName
+            SamAccountName    = $mockAdGroup.SamAccountName
             Notes             = $mockADGroup.Info
             ManagedBy         = $mockADGroup.ManagedBy
             DistinguishedName = $mockADGroup.DistinguishedName
@@ -125,6 +129,7 @@ try
             Path              = $null
             Description       = $null
             DisplayName       = $null
+            SamAccountName    = $null
             Notes             = $null
             ManagedBy         = $null
             DistinguishedName = $null
@@ -162,6 +167,7 @@ try
                     $result.Path | Should -Be $mockADGroup.Path
                     $result.Description | Should -Be $mockADGroup.Description
                     $result.DisplayName | Should -Be $mockADGroup.DisplayName
+                    $result.SamAccountName | Should -Be $mockADGroup.SamAccountName
                     $result.MembersToInclude | Should -BeNullOrEmpty
                     $result.MembersToExclude | Should -BeNullOrEmpty
                     $result.MembershipAttribute | Should -Be 'SamAccountName'
@@ -338,6 +344,7 @@ try
                     $result.Path | Should -BeNullOrEmpty
                     $result.Description | Should -BeNullOrEmpty
                     $result.DisplayName | Should -BeNullOrEmpty
+                    $result.SamAccountName | Should -BeNullOrEmpty
                     $result.Members | Should -BeNullOrEmpty
                     $result.MembersToInclude | Should -BeNullOrEmpty
                     $result.MembersToExclude | Should -BeNullOrEmpty
@@ -369,6 +376,7 @@ try
                     Path        = $mockADGroup.Path
                     Description = $mockADGroup.Description
                     DisplayName = $mockADGroup.DisplayName
+                    SamAccountName = $mockADGroup.SamAccountName
                     ManagedBy   = $mockADGroup.ManagedBy
                     Notes       = $mockADGroup.Info
                     Members     = $mockADGroup.Members
@@ -552,6 +560,7 @@ try
                     Path        = $mockADGroup.Path
                     Description = $mockADGroup.Description
                     DisplayName = $mockADGroup.DisplayName
+                    SamAccountName = $mockADGroup.SamAccountName
                     ManagedBy   = $mockADGroup.ManagedBy
                     Notes       = $mockADGroup.Info
                     Members     = $mockADGroup.Members

--- a/tests/Unit/MSFT_ADManagedServiceAccount.Tests.ps1
+++ b/tests/Unit/MSFT_ADManagedServiceAccount.Tests.ps1
@@ -74,6 +74,7 @@ try
             DistinguishedName         = "CN=TestSMSA,$mockDefaultMsaPath"
             Description               = 'Dummy StandAlone service account for unit testing'
             DisplayName               = 'TestSMSA'
+            SamAccountName            = 'TestSMSA'
             Enabled                   = $true
             KerberosEncryptionType    = 'RC4', 'AES128', 'AES256'
             ManagedPasswordPrincipals = @()
@@ -87,6 +88,7 @@ try
             DistinguishedName         = $null
             Description               = $null
             DisplayName               = $null
+            SamAccountName            = $null
             Enabled                   = $false
             ManagedPasswordPrincipals = @()
             MembershipAttribute       = $mockAdServiceAccountStandalone.MembershipAttribute
@@ -97,6 +99,7 @@ try
         $mockAdServiceAccountChanged = @{
             Description               = 'Changed description'
             DisplayName               = 'Changed displayname'
+            SamAccountName            = 'ChangedSMSA'
             KerberosEncryptionType    = 'AES128', 'AES256'
             ManagedPasswordPrincipals = $mockADUSer.SamAccountName
         }
@@ -107,6 +110,7 @@ try
             DistinguishedName         = "CN=TestGMSA,$mockDefaultMsaPath"
             Description               = 'Dummy group service account for unit testing'
             DisplayName               = 'TestGMSA'
+            SamAccountName            = 'TestGMSA'
             Enabled                   = $true
             KerberosEncryptionType    = 'RC4', 'AES128', 'AES256'
             ManagedPasswordPrincipals = $mockADUSer.SamAccountName, $mockADComputer.SamAccountName
@@ -120,6 +124,7 @@ try
             DistinguishedName         = $null
             Description               = $null
             DisplayName               = $null
+            SamAccountName            = $null
             Enabled                   = $false
             ManagedPasswordPrincipals = @()
             MembershipAttribute       = $mockAdServiceAccountGroup.MembershipAttribute
@@ -136,7 +141,7 @@ try
             Name                   = $mockAdServiceAccountStandalone.ServiceAccountName
             ObjectClass            = 'msDS-ManagedServiceAccount'
             ObjectGUID             = '91bffe90-4c84-4026-b1fc-d03671ff56ad'
-            SamAccountName         = $mockAdServiceAccountStandalone.ServiceAccountName
+            SamAccountName         = $mockAdServiceAccountStandalone.SamAccountName
             SID                    = 'S-1-5-21-1409167834-891301383-2860967316-1144'
             UserPrincipalName      = ''
         }
@@ -151,7 +156,7 @@ try
             ObjectClass                                = 'msDS-GroupManagedServiceAccount'
             ObjectGUID                                 = '91bffe90-4c84-4026-b1fc-d03671ff56ae'
             PrincipalsAllowedToRetrieveManagedPassword = $mockAdServiceAccountGroup.ManagedPasswordPrincipals
-            SamAccountName                             = $mockAdServiceAccountGroup.ServiceAccountName
+            SamAccountName                             = $mockAdServiceAccountGroup.SamAccountName
             SID                                        = 'S-1-5-21-1409167834-891301383-2860967316-1145'
             UserPrincipalName                          = ''
         }
@@ -162,6 +167,7 @@ try
             Path                      = $mockDefaultMsaPath
             Description               = $mockGetAdServiceAccountResultsStandAlone.Description
             DisplayName               = $mockGetAdServiceAccountResultsStandAlone.DisplayName
+            SamAccountName            = $mockGetAdServiceAccountResultsStandAlone.SamAccountName
             AccountType               = 'Standalone'
             Ensure                    = 'Present'
             Enabled                   = $true
@@ -177,6 +183,7 @@ try
             DistinguishedName         = $mockGetAdServiceAccountResultsGroup.DistinguishedName
             Path                      = $mockDefaultMsaPath
             Description               = $mockGetAdServiceAccountResultsGroup.Description
+            SamAccountName            = $mockGetAdServiceAccountResultsStandAlone.SamAccountName
             DisplayName               = $mockGetAdServiceAccountResultsGroup.DisplayName
             AccountType               = 'Group'
             Ensure                    = 'Present'
@@ -194,6 +201,7 @@ try
             Path                      = $null
             Description               = $null
             DisplayName               = $null
+            SamAccountName            = $null
             AccountType               = $null
             Ensure                    = 'Absent'
             Enabled                   = $false


### PR DESCRIPTION
#### Pull Request (PR) description
Adds optional parameter SamAccountName to ADUser and ADGroup resources to allow setting this property separately. This requires that GroupName be specified using something other than the SamAccountName, e.g. SID, DN, UPN, &c.

#### This Pull Request (PR) fixes the following issues
- Fixes #655
- Fixes #644

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/656)
<!-- Reviewable:end -->
