### PR TITLE
ADGroup: add SamAccountName parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - ADGroup
   - Refactored Module.
   - Refactored Unit and Integration Tests.
+  - Added SamAccountName property.
 
 ### Added
 

--- a/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.psm1
+++ b/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.psm1
@@ -71,7 +71,7 @@ function Get-TargetResource
 
     Write-Verbose -Message ($script:localizedData.RetrievingGroup -f $GroupName)
 
-    $getADGroupProperties = ('Name', 'GroupScope', 'GroupCategory', 'DistinguishedName', 'Description', 'DisplayName',
+    $getADGroupProperties = ('Name', 'GroupScope', 'GroupCategory', 'DistinguishedName', 'Description', 'DisplayName', 'SamAccountName',
         'ManagedBy', 'Members', 'Info')
 
     try
@@ -163,6 +163,7 @@ function Get-TargetResource
             Path                = Get-ADObjectParentDN -DN $adGroup.DistinguishedName
             Description         = $adGroup.Description
             DisplayName         = $adGroup.DisplayName
+            SamAccountName      = $adGroup.SamAccountName
             Members             = $adGroupMembers
             MembersToInclude    = $null
             MembersToExclude    = $null
@@ -184,6 +185,7 @@ function Get-TargetResource
             Path                = $null
             Description         = $null
             DisplayName         = $null
+            SamAccountName      = $null
             Members             = @()
             MembersToInclude    = $null
             MembersToExclude    = $null
@@ -221,6 +223,9 @@ function Get-TargetResource
 
     .PARAMETER DisplayName
         Display name of the Active Directory group.
+
+    .PARAMETER SamAccountName
+        SamAccountName of the Active Directory group.
 
     .PARAMETER Credential
         The credential to be used to perform the operation on Active Directory.
@@ -298,6 +303,11 @@ function Test-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -474,6 +484,9 @@ function Test-TargetResource
     .PARAMETER DisplayName
         Display name of the Active Directory group.
 
+    .PARAMETER SamAccountName
+        SamAccountName of the Active Directory group.
+
     .PARAMETER Credential
         The credential to be used to perform the operation on Active Directory.
 
@@ -557,6 +570,11 @@ function Set-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -904,6 +922,11 @@ function Set-TargetResource
             if ($PSBoundParameters.ContainsKey('DisplayName'))
             {
                 $newAdGroupParameters['DisplayName'] = $DisplayName
+            }
+
+            if ($PSBoundParameters.ContainsKey('SamAccountName'))
+            {
+                $newAdGroupParameters['SamAccountName'] = $SamAccountName
             }
 
             if ($PSBoundParameters.ContainsKey('ManagedBy'))

--- a/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.schema.mof
+++ b/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.schema.mof
@@ -8,6 +8,7 @@ class MSFT_ADGroup : OMI_BaseResource
     [Write, Description("Specifies if this Active Directory group should be present or absent. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Description of the Active Directory group.")] String Description;
     [Write, Description("Display name of the Active Directory group.")] String DisplayName;
+    [Write, Description("SamAccountName of the Active Directory group.")] String SamAccountName;
     [Write, Description("The credential to be used to perform the operation on Active Directory."), EmbeddedInstance("MSFT_Credential")] String Credential;
     [Write, Description("Active Directory domain controller to enact the change upon.")] String DomainController;
     [Write, Description("Active Directory group membership should match membership exactly.")] String Members[];

--- a/tests/Unit/MSFT_ADGroup.Tests.ps1
+++ b/tests/Unit/MSFT_ADGroup.Tests.ps1
@@ -43,6 +43,7 @@ try
             Path        = 'OU=OU,DC=contoso,DC=com'
             Description = 'Test AD group description'
             DisplayName = 'Test display name'
+            SamAccountName = 'TestGroup'
             Ensure      = 'Present'
             Notes       = 'This is a test AD group'
             ManagedBy   = 'CN=User 1,CN=Users,DC=contoso,DC=com'
@@ -91,6 +92,7 @@ try
             Path              = $mockGroupPath
             Description       = 'Test AD group description'
             DisplayName       = 'Test display name'
+            SamAccountName    = $mockGroupName
             Info              = 'This is a test AD group'
             ManagedBy         = 'CN=User 1,CN=Users,DC=contoso,DC=com'
             DistinguishedName = "CN=$mockGroupName,$mockGroupPath"
@@ -101,6 +103,7 @@ try
             GroupScope  = 'Universal'
             Description = 'Test AD group description changed'
             DisplayName = 'Test display name changed'
+            SamAccountName = 'TestGroup2'
             ManagedBy   = 'CN=User 2,CN=Users,DC=contoso,DC=com'
         }
 
@@ -111,6 +114,7 @@ try
             Path              = $mockADGroup.Path
             Description       = $mockADGroup.Description
             DisplayName       = $mockADGroup.DisplayName
+            SamAccountName    = $mockAdGroup.SamAccountName
             Notes             = $mockADGroup.Info
             ManagedBy         = $mockADGroup.ManagedBy
             DistinguishedName = $mockADGroup.DistinguishedName
@@ -125,6 +129,7 @@ try
             Path              = $null
             Description       = $null
             DisplayName       = $null
+            SamAccountName    = $null
             Notes             = $null
             ManagedBy         = $null
             DistinguishedName = $null
@@ -162,6 +167,7 @@ try
                     $result.Path | Should -Be $mockADGroup.Path
                     $result.Description | Should -Be $mockADGroup.Description
                     $result.DisplayName | Should -Be $mockADGroup.DisplayName
+                    $result.SamAccountName | Should -Be $mockADGroup.SamAccountName
                     $result.MembersToInclude | Should -BeNullOrEmpty
                     $result.MembersToExclude | Should -BeNullOrEmpty
                     $result.MembershipAttribute | Should -Be 'SamAccountName'
@@ -338,6 +344,7 @@ try
                     $result.Path | Should -BeNullOrEmpty
                     $result.Description | Should -BeNullOrEmpty
                     $result.DisplayName | Should -BeNullOrEmpty
+                    $result.SamAccountName | Should -BeNullOrEmpty
                     $result.Members | Should -BeNullOrEmpty
                     $result.MembersToInclude | Should -BeNullOrEmpty
                     $result.MembersToExclude | Should -BeNullOrEmpty
@@ -369,6 +376,7 @@ try
                     Path        = $mockADGroup.Path
                     Description = $mockADGroup.Description
                     DisplayName = $mockADGroup.DisplayName
+                    SamAccountName = $mockADGroup.SamAccountName
                     ManagedBy   = $mockADGroup.ManagedBy
                     Notes       = $mockADGroup.Info
                     Members     = $mockADGroup.Members
@@ -552,6 +560,7 @@ try
                     Path        = $mockADGroup.Path
                     Description = $mockADGroup.Description
                     DisplayName = $mockADGroup.DisplayName
+                    SamAccountName = $mockADGroup.SamAccountName
                     ManagedBy   = $mockADGroup.ManagedBy
                     Notes       = $mockADGroup.Info
                     Members     = $mockADGroup.Members


### PR DESCRIPTION
#### Pull Request (PR) description
Adds optional parameter SamAccountName to ADGroup resource to allow setting this property separately. This requires that GroupName be specified using something other than the SamAccountName, e.g. SID, DN, UPN, &c.

#### This Pull Request (PR) fixes the following issues
- See #655

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/658)
<!-- Reviewable:end -->
