### PR TITLE
ADManagedServiceAccount: add SamAccountName parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - ADGroup
   - Refactored Module.
   - Refactored Unit and Integration Tests.
+- ADManagedServiceAccount
+  - Added SamAccountName property.
 
 ### Added
 

--- a/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
+++ b/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
@@ -16,9 +16,7 @@ $script:errorCodeKdsRootKeyNotFound = -2146893811
         Returns the current state of an Active Directory managed service account.
 
     .PARAMETER ServiceAccountName
-    Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
-    'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20 characters
-    or less. Once created, the user's SamAccountName and CN cannot be changed.
+        Specifies the name of the object. This parameter sets the Name property of the Active Directory object. The LDAP Display Name (ldapDisplayName) of this property is 'name'. Once created, the account's Name cannot be changed. Once created, the user's SamAccountName and CN cannot be changed.
 
     .PARAMETER AccountType
         The type of managed service account. Standalone will create a Standalone Managed Service Account (sMSA) and
@@ -92,6 +90,7 @@ function Get-TargetResource
             'DistinguishedName'
             'Description'
             'DisplayName'
+            'SamAccountName'
             'ObjectClass'
             'Enabled'
             'PrincipalsAllowedToRetrieveManagedPassword'
@@ -154,6 +153,7 @@ function Get-TargetResource
             Path                      = Get-ADObjectParentDN -DN $adServiceAccount.DistinguishedName
             Description               = $adServiceAccount.Description
             DisplayName               = $adServiceAccount.DisplayName
+            SamAccountName            = $SamAccountName
             DistinguishedName         = $adServiceAccount.DistinguishedName
             Enabled                   = $adServiceAccount.Enabled
             KerberosEncryptionType    = $adServiceAccount.KerberosEncryptionType -split (', ')
@@ -171,6 +171,7 @@ function Get-TargetResource
             Path                      = $null
             Description               = $null
             DisplayName               = $null
+            SamAccountName            = $null
             DistinguishedName         = $null
             Enabled                   = $false
             KerberosEncryptionType    = @()
@@ -188,9 +189,7 @@ function Get-TargetResource
         Tests if an Active Directory managed service account is in the desired state.
 
     .PARAMETER ServiceAccountName
-        Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
-        'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20
-        characters or less. Once created, the user's SamAccountName and CN cannot be changed.
+        Specifies the name of the object. This parameter sets the Name property of the Active Directory object. The LDAP Display Name (ldapDisplayName) of this property is 'name'. Once created, the account's Name cannot be changed. Once created, the user's SamAccountName and CN cannot be changed.
 
     .PARAMETER AccountType
         The type of managed service account. Standalone will create a Standalone Managed Service Account (sMSA) and
@@ -205,6 +204,11 @@ function Get-TargetResource
 
     .PARAMETER DisplayName
         Specifies the display name of the account (ldapDisplayName 'displayName').
+
+    .PARAMETER SamAccountName
+        Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
+        'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20
+        characters or less.
 
     .PARAMETER DomainController
         Specifies the Active Directory Domain Controller instance to use to perform the task.
@@ -267,6 +271,11 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -375,9 +384,7 @@ function Test-TargetResource
         Sets the state of an Active Directory managed service account.
 
     .PARAMETER ServiceAccountName
-        Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
-        'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20
-        characters or less. Once created, the user's SamAccountName and CN cannot be changed.
+        Specifies the name of the object. This parameter sets the Name property of the Active Directory object. The LDAP Display Name (ldapDisplayName) of this property is 'name'. Once created, the account's Name cannot be changed. Once created, the user's SamAccountName and CN cannot be changed.
 
     .PARAMETER AccountType
         The type of managed service account. Standalone will create a Standalone Managed Service Account (sMSA) and
@@ -392,6 +399,11 @@ function Test-TargetResource
 
     .PARAMETER DisplayName
         Specifies the display name of the account (ldapDisplayName 'displayName').
+
+    .PARAMETER SamAccountName
+        Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName
+        'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20
+        characters or less.
 
     .PARAMETER DomainController
         Specifies the Active Directory Domain Controller instance to use to perform the task.
@@ -462,6 +474,11 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
+++ b/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
@@ -153,7 +153,7 @@ function Get-TargetResource
             Path                      = Get-ADObjectParentDN -DN $adServiceAccount.DistinguishedName
             Description               = $adServiceAccount.Description
             DisplayName               = $adServiceAccount.DisplayName
-            SamAccountName            = $SamAccountName
+            SamAccountName            = $adServiceAccount.SamAccountName
             DistinguishedName         = $adServiceAccount.DistinguishedName
             Enabled                   = $adServiceAccount.Enabled
             KerberosEncryptionType    = $adServiceAccount.KerberosEncryptionType -split (', ')

--- a/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.schema.mof
+++ b/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.schema.mof
@@ -1,11 +1,12 @@
 [ClassVersion("1.0.1.0"), FriendlyName("ADManagedServiceAccount")]
 class MSFT_ADManagedServiceAccount : OMI_BaseResource
 {
-    [Key, Description("Specifies the Security Account Manager (SAM) account name of the managed service account (ldapDisplayName 'sAMAccountName'). To be compatible with older operating systems, create a SAM account name that is 20 characters or less. Once created, the user's SamAccountName and CN cannot be changed.")] String ServiceAccountName;
+    [Key, Description("Specifies the name of the object. This parameter sets the Name property of the Active Directory object. The LDAP Display Name (ldapDisplayName) of this property is 'name'. Once created, the account's Name cannot be changed.")] String ServiceAccountName;
     [Required, Description("The type of managed service account. Standalone will create a Standalone Managed Service Account (sMSA) and Group will create a Group Managed Service Account (gMSA)."), ValueMap{"Group","Standalone"}, Values{"Group","Standalone"}] String AccountType;
     [Write, Description("Specifies the user account credentials to use to perform this task. This is only required if not executing the task on a domain controller or using the parameter DomainController."), EmbeddedInstance("MSFT_Credential")] String Credential;
     [Write, Description("Specifies the description of the account (ldapDisplayName 'description').")] String Description;
     [Write, Description("Specifies the display name of the account (ldapDisplayName 'displayName').")] String DisplayName;
+    [Write, Description("Specifies the Security Account Manager (SAM) account name of the service account. To be compatible with older operating systems, create a SAM account name that is 20 characters or less. If the string value provided is not terminated with a '$' character, the system adds one if needed. The LDAP display name (ldapDisplayName) for this property is 'sAMAccountName'.")] String SamAccountName;
     [Write, Description("Specifies the Active Directory Domain Controller instance to use to perform the task. This is only required if not executing the task on a domain controller.")] String DomainController;
     [Write, Description("Specifies whether the user account is created or deleted. If not specified, this value defaults to Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Specifies which Kerberos encryption types the account supports when creating service tickets. This value sets the encryption types supported flags of the Active Directory msDS-SupportedEncryptionTypes attribute."),ValueMap{"None","RC4","AES128","AES256"}, Values{"None","RC4","AES128","AES256"}] String KerberosEncryptionType[];

--- a/tests/Unit/MSFT_ADManagedServiceAccount.Tests.ps1
+++ b/tests/Unit/MSFT_ADManagedServiceAccount.Tests.ps1
@@ -74,6 +74,7 @@ try
             DistinguishedName         = "CN=TestSMSA,$mockDefaultMsaPath"
             Description               = 'Dummy StandAlone service account for unit testing'
             DisplayName               = 'TestSMSA'
+            SamAccountName            = 'TestSMSA'
             Enabled                   = $true
             KerberosEncryptionType    = 'RC4', 'AES128', 'AES256'
             ManagedPasswordPrincipals = @()
@@ -87,6 +88,7 @@ try
             DistinguishedName         = $null
             Description               = $null
             DisplayName               = $null
+            SamAccountName            = $null
             Enabled                   = $false
             ManagedPasswordPrincipals = @()
             MembershipAttribute       = $mockAdServiceAccountStandalone.MembershipAttribute
@@ -97,6 +99,7 @@ try
         $mockAdServiceAccountChanged = @{
             Description               = 'Changed description'
             DisplayName               = 'Changed displayname'
+            SamAccountName            = 'ChangedSMSA'
             KerberosEncryptionType    = 'AES128', 'AES256'
             ManagedPasswordPrincipals = $mockADUSer.SamAccountName
         }
@@ -107,6 +110,7 @@ try
             DistinguishedName         = "CN=TestGMSA,$mockDefaultMsaPath"
             Description               = 'Dummy group service account for unit testing'
             DisplayName               = 'TestGMSA'
+            SamAccountName            = 'TestGMSA'
             Enabled                   = $true
             KerberosEncryptionType    = 'RC4', 'AES128', 'AES256'
             ManagedPasswordPrincipals = $mockADUSer.SamAccountName, $mockADComputer.SamAccountName
@@ -120,6 +124,7 @@ try
             DistinguishedName         = $null
             Description               = $null
             DisplayName               = $null
+            SamAccountName            = $null
             Enabled                   = $false
             ManagedPasswordPrincipals = @()
             MembershipAttribute       = $mockAdServiceAccountGroup.MembershipAttribute
@@ -136,7 +141,7 @@ try
             Name                   = $mockAdServiceAccountStandalone.ServiceAccountName
             ObjectClass            = 'msDS-ManagedServiceAccount'
             ObjectGUID             = '91bffe90-4c84-4026-b1fc-d03671ff56ad'
-            SamAccountName         = $mockAdServiceAccountStandalone.ServiceAccountName
+            SamAccountName         = $mockAdServiceAccountStandalone.SamAccountName
             SID                    = 'S-1-5-21-1409167834-891301383-2860967316-1144'
             UserPrincipalName      = ''
         }
@@ -151,7 +156,7 @@ try
             ObjectClass                                = 'msDS-GroupManagedServiceAccount'
             ObjectGUID                                 = '91bffe90-4c84-4026-b1fc-d03671ff56ae'
             PrincipalsAllowedToRetrieveManagedPassword = $mockAdServiceAccountGroup.ManagedPasswordPrincipals
-            SamAccountName                             = $mockAdServiceAccountGroup.ServiceAccountName
+            SamAccountName                             = $mockAdServiceAccountGroup.SamAccountName
             SID                                        = 'S-1-5-21-1409167834-891301383-2860967316-1145'
             UserPrincipalName                          = ''
         }
@@ -162,6 +167,7 @@ try
             Path                      = $mockDefaultMsaPath
             Description               = $mockGetAdServiceAccountResultsStandAlone.Description
             DisplayName               = $mockGetAdServiceAccountResultsStandAlone.DisplayName
+            SamAccountName            = $mockGetAdServiceAccountResultsStandAlone.SamAccountName
             AccountType               = 'Standalone'
             Ensure                    = 'Present'
             Enabled                   = $true
@@ -177,6 +183,7 @@ try
             DistinguishedName         = $mockGetAdServiceAccountResultsGroup.DistinguishedName
             Path                      = $mockDefaultMsaPath
             Description               = $mockGetAdServiceAccountResultsGroup.Description
+            SamAccountName            = $mockGetAdServiceAccountResultsStandAlone.SamAccountName
             DisplayName               = $mockGetAdServiceAccountResultsGroup.DisplayName
             AccountType               = 'Group'
             Ensure                    = 'Present'
@@ -194,6 +201,7 @@ try
             Path                      = $null
             Description               = $null
             DisplayName               = $null
+            SamAccountName            = $null
             AccountType               = $null
             Ensure                    = 'Absent'
             Enabled                   = $false


### PR DESCRIPTION
#### Pull Request (PR) description
Adds optional parameter SamAccountName to ADManagedServiceAccount resource to allow setting this property separately. This requires that ServiceAccountName be specified using something other than the SamAccountName, e.g. SID, DN, UPN, &c.

#### This Pull Request (PR) fixes the following issues
- See #655
- Fixes #644

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/activedirectorydsc/659)
<!-- Reviewable:end -->
