### PR TITLE
ADUser: add SamAccountName parameter

### DIFF
--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.PropertyMap.psd1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.PropertyMap.psd1
@@ -19,6 +19,12 @@
             Array              = $false
         }
         @{
+            Parameter          = 'SamAccountName'
+            ADProperty         = 'SamAccountName'
+            UseCmdletParameter = $true
+            Array              = $false
+        }
+        @{
             Parameter          = 'Path'
             ADProperty         = 'distinguishedName'
             UseCmdletParameter = $true

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -187,7 +187,7 @@ function Get-TargetResource
 
     .PARAMETER UserName
         Specifies the account name of the user. (You can identify a user by its distinguished
-    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
+    name (DN), GUID, security identifier (SID), or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER Password
         Specifies a new password value for the account.
@@ -204,6 +204,9 @@ function Get-TargetResource
 
     .PARAMETER DisplayName
         Specifies the display name of the object (ldapDisplayName 'displayName').
+
+    .PARAMETER SamAccountName
+        Specifies the SamAccountName of the object (ldapDisplayName 'SamAccountName').
 
     .PARAMETER Path
         Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created.
@@ -305,7 +308,7 @@ function Get-TargetResource
     .PARAMETER LogonWorkstations
         Specifies the computers that the user can access. To specify more than one computer, create a single
         comma-separated list. You can identify a computer by using the Security Account Manager (SAM) account name
-        (sAMAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of
+        (SamAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of
         the computer (ldapDisplayName 'userWorkStations').
 
     .PARAMETER Organization
@@ -433,6 +436,11 @@ function Test-TargetResource
         [ValidateNotNull()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -872,7 +880,7 @@ function Test-TargetResource
 
     .PARAMETER UserName
         Specifies the account name of the user. (You can identify a user by its distinguished
-    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
+    name (DN), GUID, security identifier (SID), or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER Password
         Specifies a new password value for the account.
@@ -889,6 +897,9 @@ function Test-TargetResource
 
     .PARAMETER DisplayName
         Specifies the display name of the object (ldapDisplayName 'displayName').
+
+    .PARAMETER SamAccountName
+        Specifies the SamAccountName of the object (ldapDisplayName 'SamAccountName').
 
     .PARAMETER Path
         Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created.
@@ -990,7 +1001,7 @@ function Test-TargetResource
     .PARAMETER LogonWorkstations
         Specifies the computers that the user can access. To specify more than one computer, create a single
         comma-separated list. You can identify a computer by using the Security Account Manager (SAM) account name
-        (sAMAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of
+        (SamAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of
         the computer (ldapDisplayName 'userWorkStations').
 
     .PARAMETER Organization
@@ -1127,6 +1138,11 @@ function Set-TargetResource
         [ValidateNotNull()]
         [System.String]
         $DisplayName,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $SamAccountName,
 
         [Parameter()]
         [ValidateNotNull()]

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -27,7 +27,8 @@ $adPropertyMap = (Import-PowerShellDataFile -Path $adPropertyMapPath).Parameters
         Name of the domain where the user account is located (only used if password is managed).
 
     .PARAMETER UserName
-        Specifies the Security Account Manager (SAM) account name of the user (ldapDisplayName 'sAMAccountName').
+        Specifies the account name of the user. (You can identify a user by its distinguished
+    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER DomainController
         Specifies the Active Directory Domain Services instance to use to perform the task.
@@ -185,7 +186,8 @@ function Get-TargetResource
         Name of the domain where the user account is located (only used if password is managed).
 
     .PARAMETER UserName
-        Specifies the Security Account Manager (SAM) account name of the user (ldapDisplayName 'sAMAccountName').
+        Specifies the account name of the user. (You can identify a user by its distinguished
+    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER Password
         Specifies a new password value for the account.
@@ -869,7 +871,8 @@ function Test-TargetResource
         Name of the domain where the user account is located (only used if password is managed).
 
     .PARAMETER UserName
-        Specifies the Security Account Manager (SAM) account name of the user (ldapDisplayName 'sAMAccountName').
+        Specifies the account name of the user. (You can identify a user by its distinguished
+    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)
 
     .PARAMETER Password
         Specifies a new password value for the account.
@@ -1506,7 +1509,7 @@ function Set-TargetResource
 
                 Write-Debug -Message ('New-ADUser Parameters:' + ($newADUserParams | Out-String))
 
-                $newADUser = New-ADUser @newADUserParams -SamAccountName $UserName -Passthru
+                $newADUser = New-ADUser @newADUserParams -Name $UserName -Passthru
 
                 if ($updateCnRequired)
                 {

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
@@ -2,7 +2,8 @@
 class MSFT_ADUser : OMI_BaseResource
 {
     [Key, Description("Name of the domain where the user account is located (only used if password is managed).")] String DomainName;
-    [Key, Description("Specifies the Security Account Manager (SAM) account name of the user (ldapDisplayName 'sAMAccountName').")] String UserName;
+    [Key, Description("Specifies the account name of the user. (You can identify a user by its distinguished
+    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)")] String UserName;
     [Write, Description("Specifies a new password value for the account."), EmbeddedInstance("MSFT_Credential")] String Password;
     [Write, Description("Specifies whether the user account should be present or absent. Default value is 'Present'."), ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
     [Write, Description("Specifies the common name assigned to the user account (ldapDisplayName 'cn'). If not specified the default value will be the same value provided in parameter UserName.")] String CommonName;

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
@@ -2,13 +2,13 @@
 class MSFT_ADUser : OMI_BaseResource
 {
     [Key, Description("Name of the domain where the user account is located (only used if password is managed).")] String DomainName;
-    [Key, Description("Specifies the account name of the user. (You can identify a user by its distinguished
-    name (DN), GUID, security identifier (SID) or Security Accounts Manager (SAM) account name.)")] String UserName;
+    [Key, Description("Specifies the account name of the user. (You can identify a user by its distinguished name (DN), GUID, security identifier (SID), or Security Accounts Manager (SAM) account name.)")] String UserName;
     [Write, Description("Specifies a new password value for the account."), EmbeddedInstance("MSFT_Credential")] String Password;
     [Write, Description("Specifies whether the user account should be present or absent. Default value is 'Present'."), ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
     [Write, Description("Specifies the common name assigned to the user account (ldapDisplayName 'cn'). If not specified the default value will be the same value provided in parameter UserName.")] String CommonName;
     [Write, Description("Specifies the User Principal Name (UPN) assigned to the user account (ldapDisplayName 'userPrincipalName').")] String UserPrincipalName;
     [Write, Description("Specifies the display name of the object (ldapDisplayName 'displayName').")] String DisplayName;
+    [Write, Description("Specifies the SamAccountName of the object (ldapDisplayName 'SamAccountName').")] String SamAccountName;
     [Write, Description("Specifies the X.500 path of the Organizational Unit (OU) or container where the new object is created.")] String Path;
     [Write, Description("Specifies the user's given name (ldapDisplayName 'givenName').")] String GivenName;
     [Write, Description("Specifies the initials that represent part of a user's name (ldapDisplayName 'initials').")] String Initials;
@@ -41,7 +41,7 @@ class MSFT_ADUser : OMI_BaseResource
     [Write, Description("Specifies the user's pager number (ldapDisplayName 'pager').")] String Pager;
     [Write, Description("Specifies the user's IP telephony phone number (ldapDisplayName 'ipPhone').")] String IPPhone;
     [Write, Description("Specifies the user's manager specified as a Distinguished Name (ldapDisplayName 'manager').")] String Manager;
-    [Write, Description("Specifies the computers that the user can access. To specify more than one computer, create a single comma-separated list. You can identify a computer by using the Security Account Manager (SAM) account name (sAMAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of the computer. The LDAP display name (ldapDisplayName) for this property is userWorkStations.")] String LogonWorkstations;
+    [Write, Description("Specifies the computers that the user can access. To specify more than one computer, create a single comma-separated list. You can identify a computer by using the Security Account Manager (SAM) account name (SamAccountName) or the DNS host name of the computer. The SAM account name is the same as the NetBIOS name of the computer. The LDAP display name (ldapDisplayName) for this property is userWorkStations.")] String LogonWorkstations;
     [Write, Description("Specifies the user's organization. This parameter sets the Organization property of a user object. The LDAP display name (ldapDisplayName) of this property is 'o'.")] String Organization;
     [Write, Description("Specifies a name in addition to a user's given name and surname, such as the user's middle name. This parameter sets the OtherName property of a user object. The LDAP display name (ldapDisplayName) of this property is 'middleName'.")] String OtherName;
     [Write, Description("Specifies if the account is enabled. Default value is $true.")] Boolean Enabled;


### PR DESCRIPTION
#### Pull Request (PR) description
Adds optional parameter SamAccountName to ADUser resource to allow setting this property separately. This requires that UserName be specified using something other than the SamAccountName, e.g. SID, DN, UPN, &c.

#### This Pull Request (PR) fixes the following issues
- See #655

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
