### PR TITLE
ADReplicationSiteLink: Fix for Options when ReplicationFrequencyInMinute not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - ADOrganizationalUnit
   - Added DomainController Parameter.
 
+### Fixed
+
+- ADReplicationSiteLink
+  - Allow OptionChangeNotification, OptionTwoWaySync and OptionDisableCompression to be updated even if
+    ReplicationFrequencyInMinutes is not set ([issue #637](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/637)).
+
 ## [6.2.0] - 2022-05-01
 
 ### Changed

--- a/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
+++ b/source/DSCResources/MSFT_ADReplicationSiteLink/MSFT_ADReplicationSiteLink.psm1
@@ -287,7 +287,7 @@ function Set-TargetResource
                 $setADReplicationSiteLinkParameters['ReplicationFrequencyInMinutes'] = $ReplicationFrequencyInMinutes
             }
 
-            if ($PSBoundParameters.ContainsKey('ReplicationFrequencyInMinutes') -and
+            if ($PSBoundParameters.ContainsKey('OptionChangeNotification') -and
                 $OptionChangeNotification -ne $currentADSiteLink.OptionChangeNotification)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
@@ -299,7 +299,7 @@ function Set-TargetResource
                 $desiredChangeNotification = $currentADSiteLink.OptionChangeNotification
             }
 
-            if ($PSBoundParameters.ContainsKey('ReplicationFrequencyInMinutes') -and
+            if ($PSBoundParameters.ContainsKey('OptionTwoWaySync') -and
                 $OptionTwoWaySync -ne $currentADSiteLink.OptionTwoWaySync)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f
@@ -311,7 +311,7 @@ function Set-TargetResource
                 $desiredTwoWaySync = $currentADSiteLink.OptionTwoWaySync
             }
 
-            if ($PSBoundParameters.ContainsKey('ReplicationFrequencyInMinutes') -and
+            if ($PSBoundParameters.ContainsKey('OptionDisableCompression') -and
                 $OptionDisableCompression -ne $currentADSiteLink.OptionDisableCompression)
             {
                 Write-Verbose -Message ($script:localizedData.SettingProperty -f


### PR DESCRIPTION
#### Pull Request (PR) description

Allow OptionChangeNotification, OptionTwoWaySync and OptionDisableCompression to be updated even if ReplicationFrequencyInMinutes is not set (fixes #637)

#### This Pull Request (PR) fixes the following issues

- Fixes #637

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ActiveDirectoryDsc/699)
<!-- Reviewable:end -->
