### PR TITLE
ADSRootKey: Resolved 'String was not recognized as a valid DateTime' in non-US cultures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - Move test pipeline to Windows PowerShell. The hosted agent was updated
   to PowerShell 7.4.1. That broke the ASKDSKey unit tests that has a helper
   function (`Copy-ArrayObjects`) that serializes objects.
+- ADSRootKey
+  -  Resolved 'String was not recognized as a valid DateTime' in non-US cultures ([issue #702](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/702)).
 
 ## [6.3.0] - 2023-08-24
 

--- a/source/DSCResources/MSFT_ADKDSKey/MSFT_ADKDSKey.psm1
+++ b/source/DSCResources/MSFT_ADKDSKey/MSFT_ADKDSKey.psm1
@@ -107,7 +107,7 @@ function Get-TargetResource
         elseif ($kdsRootKey)
         {
             $targetResource['Ensure'] = 'Present'
-            $targetResource['EffectiveTime'] = ([DateTime]::Parse($kdsRootKey.EffectiveTime)).ToString()
+            $targetResource['EffectiveTime'] = $kdsRootKey.EffectiveTime.ToString('o')
             $targetResource['CreationTime'] = $kdsRootKey.CreationTime
             $targetResource['KeyId'] = $kdsRootKey.KeyId
             $targetResource['DistinguishedName'] = 'CN={0},CN=Master Root Keys,CN=Group Key Distribution Service,CN=Services,CN=Configuration,{1}' -f


### PR DESCRIPTION
#### Pull Request (PR) description

Fix #702 where 'String was not recognised as a valid DateTime' can occur with non en-US cultures

#### This Pull Request (PR) fixes the following issues

- Fixes #702 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ActiveDirectoryDsc/703)
<!-- Reviewable:end -->
