### PR TITLE
ADDomain: Add DomainType support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Fixed
+
+- Move test pipeline to Windows PowerShell. The hosted agent was updated
+  to PowerShell 7.4.1. That broke the ASKDSKey unit tests that has a helper
+  function (`Copy-ArrayObjects`) that serializes objects.
+
 ## [6.3.0] - 2023-08-24
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - ADDomain
   - Added support for creating a Tree domain via the DomainType field
     ([issue #689](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/689))
-    ([issue #692](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/689)).
+    ([issue #692](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/692)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - Move test pipeline to Windows PowerShell. The hosted agent was updated
   to PowerShell 7.4.1. That broke the ASKDSKey unit tests that has a helper
   function (`Copy-ArrayObjects`) that serializes objects.
+- ADSRootKey
+  -  Resolved 'String was not recognized as a valid DateTime' in non-US cultures ([issue #702](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/702)).
 
 ## [6.3.0] - 2023-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Added
+
+- ADDomain
+  - Added support for creating a Tree domain via the DomainType field
+    ([issue #689](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/689))
+    ([issue #692](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/689)).
+
 ### Fixed
 
 - Move test pipeline to Windows PowerShell. The hosted agent was updated

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ stages:
             inputs:
               filePath: './build.ps1'
               arguments: "-Tasks test -PesterScript 'tests/Unit'"
-              pwsh: true
+              pwsh: false
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'
             condition: succeededOrFailed()

--- a/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
+++ b/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
@@ -30,6 +30,11 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER ParentDomainName
         Fully qualified domain name (FQDN) of the parent domain.
 
+    .PARAMETER DomainType
+        When installing a new domain, specifies whether it is a new domain tree in an existing forest
+        ('TreeDomain'), or a child of an existing domain ('ChildDomain'). Only used when installing a
+        new domain. Default value is 'ChildDomain'.
+
     .NOTES
         Used Functions:
             Name                           | Module
@@ -62,7 +67,12 @@ function Get-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $ParentDomainName
+        $ParentDomainName,
+
+        [Parameter()]
+        [ValidateSet('ChildDomain', 'TreeDomain')]
+        [System.String]
+        $DomainType = 'ChildDomain'
     )
 
     Assert-Module -ModuleName 'ADDSDeployment' -ImportModule
@@ -126,7 +136,7 @@ function Get-TargetResource
             ParentDomainName              = $domain.ParentDomain
             DomainNetBiosName             = $domain.NetBIOSName
             DnsDelegationCredential       = $null
-            DomainType                    = $null
+            DomainType                    = $DomainType
             DatabasePath                  = $serviceNTDS.'DSA Working Directory'
             LogPath                       = $serviceNTDS.'Database log files path'
             SysvolPath                    = $serviceNETLOGON.SysVol -replace '\\sysvol$', ''
@@ -146,7 +156,7 @@ function Get-TargetResource
             ParentDomainName              = $ParentDomainName
             DomainNetBiosName             = $null
             DnsDelegationCredential       = $null
-            DomainType                    = $null
+            DomainType                    = $DomainType
             DatabasePath                  = $null
             LogPath                       = $null
             SysvolPath                    = $null
@@ -189,8 +199,9 @@ function Get-TargetResource
         Credential used for creating DNS delegation.
 
     .PARAMETER DomainType
-        Specifies whether the domain is a new domain tree in an existing forest ('TreeDomain'),
-        or a child of an existing domain ('ChildDomain'). Default value is 'ChildDomain'.
+        When installing a new domain, specifies whether it is a new domain tree in an existing forest
+        ('TreeDomain'), or a child of an existing domain ('ChildDomain'). Only used when installing a
+        new domain. Default value is 'ChildDomain'.
 
     .PARAMETER DatabasePath
         Path to a directory that contains the domain database.
@@ -339,8 +350,9 @@ function Test-TargetResource
         Credential used for creating DNS delegation.
 
     .PARAMETER DomainType
-        Specifies whether the domain is a new domain tree in an existing forest ('TreeDomain'),
-        or a child of an existing domain ('ChildDomain'). Default value is 'ChildDomain'.
+        When installing a new domain, specifies whether it is a new domain tree in an existing forest
+        ('TreeDomain'), or a child of an existing domain ('ChildDomain'). Only used when installing a
+        new domain. Default value is 'ChildDomain'.
 
     .PARAMETER DatabasePath
         Path to a directory that contains the domain database.
@@ -494,11 +506,7 @@ function Set-TargetResource
             $installADDSParameters['Credential'] = $Credential
             $installADDSParameters['NewDomainName'] = $DomainName
             $installADDSParameters['ParentDomainName'] = $ParentDomainName
-
-            if ($PSBoundParameters.ContainsKey('DomainType'))
-            {
-                $installADDSParameters['DomainType'] = $DomainType
-            }
+            $installADDSParameters['DomainType'] = $DomainType
 
             if ($PSBoundParameters.ContainsKey('DomainNetBiosName'))
             {

--- a/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
+++ b/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
@@ -126,6 +126,7 @@ function Get-TargetResource
             ParentDomainName              = $domain.ParentDomain
             DomainNetBiosName             = $domain.NetBIOSName
             DnsDelegationCredential       = $null
+            DomainType                    = $null
             DatabasePath                  = $serviceNTDS.'DSA Working Directory'
             LogPath                       = $serviceNTDS.'Database log files path'
             SysvolPath                    = $serviceNETLOGON.SysVol -replace '\\sysvol$', ''
@@ -145,6 +146,7 @@ function Get-TargetResource
             ParentDomainName              = $ParentDomainName
             DomainNetBiosName             = $null
             DnsDelegationCredential       = $null
+            DomainType                    = $null
             DatabasePath                  = $null
             LogPath                       = $null
             SysvolPath                    = $null
@@ -185,6 +187,10 @@ function Get-TargetResource
 
     .PARAMETER DnsDelegationCredential
         Credential used for creating DNS delegation.
+
+    .PARAMETER DomainType
+        Specifies whether the domain is a new domain tree in an existing forest ('TreeDomain'),
+        or a child of an existing domain ('ChildDomain'). Default value is 'ChildDomain'.
 
     .PARAMETER DatabasePath
         Path to a directory that contains the domain database.
@@ -238,6 +244,11 @@ function Test-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         $DnsDelegationCredential,
+
+        [Parameter()]
+        [ValidateSet('ChildDomain', 'TreeDomain')]
+        [System.String]
+        $DomainType = 'ChildDomain',
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -327,6 +338,10 @@ function Test-TargetResource
     .PARAMETER DnsDelegationCredential
         Credential used for creating DNS delegation.
 
+    .PARAMETER DomainType
+        Specifies whether the domain is a new domain tree in an existing forest ('TreeDomain'),
+        or a child of an existing domain ('ChildDomain'). Default value is 'ChildDomain'.
+
     .PARAMETER DatabasePath
         Path to a directory that contains the domain database.
 
@@ -386,6 +401,11 @@ function Set-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         $DnsDelegationCredential,
+
+        [Parameter()]
+        [ValidateSet('ChildDomain', 'TreeDomain')]
+        [System.String]
+        $DomainType = 'ChildDomain',
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -474,7 +494,11 @@ function Set-TargetResource
             $installADDSParameters['Credential'] = $Credential
             $installADDSParameters['NewDomainName'] = $DomainName
             $installADDSParameters['ParentDomainName'] = $ParentDomainName
-            $installADDSParameters['DomainType'] = 'ChildDomain'
+
+            if ($PSBoundParameters.ContainsKey('DomainType'))
+            {
+                $installADDSParameters['DomainType'] = $DomainType
+            }
 
             if ($PSBoundParameters.ContainsKey('DomainNetBiosName'))
             {

--- a/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.schema.mof
+++ b/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.schema.mof
@@ -7,6 +7,7 @@ class MSFT_ADDomain : OMI_BaseResource
     [Write, Description("Fully qualified domain name (FQDN) of the parent domain.")] String ParentDomainName;
     [Write, Description("NetBIOS name for the new domain.")] String DomainNetBiosName;
     [Write, Description("Credential used for creating DNS delegation."), EmbeddedInstance("MSFT_Credential")] String DnsDelegationCredential;
+    [Write, Description("Specifies whether the domain is a new domain tree in an existing forest ('TreeDomain'), or a child of an existing domain ('ChildDomain'). Default value is 'ChildDomain'."), ValueMap{"ChildDomain", "TreeDomain"}, Values{"ChildDomain", "TreeDomain"}] String DomainType;
     [Write, Description("Path to a directory that contains the domain database.")] String DatabasePath;
     [Write, Description("Path to a directory for the log file that will be written.")] String LogPath;
     [Write, Description("Path to a directory where the Sysvol file will be written.")] String SysvolPath;

--- a/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.schema.mof
+++ b/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.schema.mof
@@ -7,7 +7,7 @@ class MSFT_ADDomain : OMI_BaseResource
     [Write, Description("Fully qualified domain name (FQDN) of the parent domain.")] String ParentDomainName;
     [Write, Description("NetBIOS name for the new domain.")] String DomainNetBiosName;
     [Write, Description("Credential used for creating DNS delegation."), EmbeddedInstance("MSFT_Credential")] String DnsDelegationCredential;
-    [Write, Description("Specifies whether the domain is a new domain tree in an existing forest ('TreeDomain'), or a child of an existing domain ('ChildDomain'). Default value is 'ChildDomain'."), ValueMap{"ChildDomain", "TreeDomain"}, Values{"ChildDomain", "TreeDomain"}] String DomainType;
+    [Write, Description("When installing a new domain, specifies whether it is a new domain tree in an existing forest ('TreeDomain'), or a child of an existing domain ('ChildDomain'). Only used when installing a new domain. Default value is 'ChildDomain'."), ValueMap{"ChildDomain", "TreeDomain"}, Values{"ChildDomain", "TreeDomain"}] String DomainType;
     [Write, Description("Path to a directory that contains the domain database.")] String DatabasePath;
     [Write, Description("Path to a directory for the log file that will be written.")] String LogPath;
     [Write, Description("Path to a directory where the Sysvol file will be written.")] String SysvolPath;

--- a/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
+++ b/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
@@ -32,6 +32,11 @@
     Write - PSCredential
     Credential used for creating DNS delegation.
 
+.PARAMETER DomainType
+    Write - String
+    Allowed values: ChildDomain, TreeDomain
+    Specifies whether the domain is a new domain tree in an existing forest ('TreeDomain'), or a child of an existing domain ('ChildDomain'). Default value is 'ChildDomain'.
+
 .PARAMETER DatabasePath
     Write - String
     Path to a directory that contains the domain database.
@@ -160,5 +165,3 @@ Configuration ADDomain_NewChildDomain_Config
         }
     }
 }
-
-

--- a/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
+++ b/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
@@ -172,7 +172,7 @@ Configuration ADDomain_NewChildDomain_Config
 This configuration will create a new domain tree in an existing forest with
 a Domain Functional Level of Windows Server 2012R2.
 
-Configuration ADDomain_NewTreeDomain_Config
+Configuration ADDomain_NewDomainTree_Config
 {
     param
     (

--- a/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
+++ b/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
@@ -160,6 +160,7 @@ Configuration ADDomain_NewChildDomain_Config
             DomainName                    = 'child'
             Credential                    = $Credential
             SafemodeAdministratorPassword = $SafeModePassword
+            DomainType                    = 'ChildDomain'
             DomainMode                    = 'Win2012R2'
             ParentDomainName              = 'contoso.com'
         }

--- a/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
+++ b/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
@@ -204,7 +204,7 @@ Configuration ADDomain_NewTreeDomain_Config
             Ensure = 'Present'
         }
 
-        ADDomain 'child'
+        ADDomain 'fabrikam.com'
         {
             DomainName                    = 'fabrikam.com'
             Credential                    = $Credential

--- a/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
+++ b/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
@@ -166,3 +166,52 @@ Configuration ADDomain_NewChildDomain_Config
         }
     }
 }
+
+.EXAMPLE 3
+
+This configuration will create a new domain tree in an existing forest with
+a Domain Functional Level of Windows Server 2012R2.
+
+Configuration ADDomain_NewTreeDomain_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SafeModePassword
+    )
+
+    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName ActiveDirectoryDsc
+
+    node 'localhost'
+    {
+        WindowsFeature 'ADDS'
+        {
+            Name   = 'AD-Domain-Services'
+            Ensure = 'Present'
+        }
+
+        WindowsFeature 'RSAT'
+        {
+            Name   = 'RSAT-AD-PowerShell'
+            Ensure = 'Present'
+        }
+
+        ADDomain 'child'
+        {
+            DomainName                    = 'fabrikam.com'
+            Credential                    = $Credential
+            SafemodeAdministratorPassword = $SafeModePassword
+            DomainType                    = 'TreeDomain'
+            DomainMode                    = 'Win2012R2'
+            ParentDomainName              = 'contoso.com'
+        }
+    }
+}

--- a/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
+++ b/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
@@ -35,7 +35,7 @@
 .PARAMETER DomainType
     Write - String
     Allowed values: ChildDomain, TreeDomain
-    Specifies whether the domain is a new domain tree in an existing forest ('TreeDomain'), or a child of an existing domain ('ChildDomain'). Default value is 'ChildDomain'.
+    When installing a new domain, specifies whether it is a new domain tree in an existing forest ('TreeDomain'), or a child of an existing domain ('ChildDomain'). Only used when installing a new domain. Default value is 'ChildDomain'.
 
 .PARAMETER DatabasePath
     Write - String

--- a/source/DSCResources/MSFT_ADKDSKey/MSFT_ADKDSKey.psm1
+++ b/source/DSCResources/MSFT_ADKDSKey/MSFT_ADKDSKey.psm1
@@ -107,7 +107,7 @@ function Get-TargetResource
         elseif ($kdsRootKey)
         {
             $targetResource['Ensure'] = 'Present'
-            $targetResource['EffectiveTime'] = ([DateTime]::Parse($kdsRootKey.EffectiveTime)).ToString()
+            $targetResource['EffectiveTime'] = $kdsRootKey.EffectiveTime.ToString('o')
             $targetResource['CreationTime'] = $kdsRootKey.CreationTime
             $targetResource['KeyId'] = $kdsRootKey.KeyId
             $targetResource['DistinguishedName'] = 'CN={0},CN=Master Root Keys,CN=Group Key Distribution Service,CN=Services,CN=Configuration,{1}' -f

--- a/source/Examples/Resources/ADDomain/3-ADDomain_NewDomainTree_Config.ps1
+++ b/source/Examples/Resources/ADDomain/3-ADDomain_NewDomainTree_Config.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 .VERSION 1.0.1
-.GUID 40a01066-4c01-4115-b7a8-c21b51ac4ed3
+.GUID 77c6a983-7bb0-4457-88e2-3e4f36727748
 .AUTHOR DSC Community
 .COMPANYNAME DSC Community
 .COPYRIGHT DSC Community contributors. All rights reserved.
@@ -17,12 +17,12 @@ Updated author, copyright notice, and URLs.
 
 <#
     .DESCRIPTION
-        This configuration will create a new child domain in an existing forest with
+        This configuration will create a new domain tree in an existing forest with
         a Domain Functional Level of Windows Server 2016 (WinThreshold).
         The credential parameter must contain the domain qualified credentials of a
-        user in the forest who has permissions to create a new child domain.
+        user in the forest who has permissions to create a new domain tree.
 #>
-Configuration ADDomain_NewChildDomain_Config
+Configuration ADDomain_NewDomainTree_Config
 {
     param
     (
@@ -54,12 +54,12 @@ Configuration ADDomain_NewChildDomain_Config
             Ensure = 'Present'
         }
 
-        ADDomain 'child'
+        ADDomain 'fabrikam.com'
         {
-            DomainName                    = 'child'
+            DomainName                    = 'fabrikam.com'
             Credential                    = $Credential
             SafemodeAdministratorPassword = $SafeModePassword
-            DomainType                    = 'ChildDomain'
+            DomainType                    = 'TreeDomain'
             DomainMode                    = 'WinThreshold'
             ParentDomainName              = 'contoso.com'
         }

--- a/tests/Unit/MSFT_ADDomain.Tests.ps1
+++ b/tests/Unit/MSFT_ADDomain.Tests.ps1
@@ -44,6 +44,7 @@ try
         $mockDnsRoot = $mockDomainName
         $mockParentDomainName = ''
         $mockDomainFQDN = $mockDomainName
+        $mockDomainType = 'ChildDomain'
         $mockNTDSPath = 'C:\Windows\NTDS'
         $mockSysVolPath = 'C:\Windows\SysVol'
         $mockDomainSysVolPath = Join-Path -Path $mockSysVolPath -ChildPath $mockDomainName
@@ -67,7 +68,7 @@ try
             ParentDomainName              = $mockParentDomainName
             DomainNetBiosName             = $null
             DnsDelegationCredential       = $null
-            DomainType                    = $null
+            DomainType                    = $mockDomainType
             DatabasePath                  = $null
             LogPath                       = $null
             SysvolPath                    = $null
@@ -85,7 +86,7 @@ try
             ParentDomainName              = $mockParentDomainName
             DomainNetBiosName             = $mockNetBiosName
             DnsDelegationCredential       = $null
-            DomainType                    = $null
+            DomainType                    = $mockDomainType
             DatabasePath                  = $mockNTDSPath
             LogPath                       = $mockNTDSPath
             SysvolPath                    = $mockSysVolPath

--- a/tests/Unit/MSFT_ADDomain.Tests.ps1
+++ b/tests/Unit/MSFT_ADDomain.Tests.ps1
@@ -67,6 +67,7 @@ try
             ParentDomainName              = $mockParentDomainName
             DomainNetBiosName             = $null
             DnsDelegationCredential       = $null
+            DomainType                    = $null
             DatabasePath                  = $null
             LogPath                       = $null
             SysvolPath                    = $null
@@ -84,6 +85,7 @@ try
             ParentDomainName              = $mockParentDomainName
             DomainNetBiosName             = $mockNetBiosName
             DnsDelegationCredential       = $null
+            DomainType                    = $null
             DatabasePath                  = $mockNTDSPath
             LogPath                       = $mockNTDSPath
             SysvolPath                    = $mockSysVolPath

--- a/tests/Unit/MSFT_ADDomain.Tests.ps1
+++ b/tests/Unit/MSFT_ADDomain.Tests.ps1
@@ -265,6 +265,7 @@ try
         Describe 'ADDomain\Set-TargetResource' {
             $mockDomainName = 'present.com'
             $mockParentDomainName = 'parent.com'
+            $mockDomainType = 'ChildDomain'
             $mockDomainNetBIOSNameName = 'PRESENT'
             $mockDomainForestMode = 'WinThreshold'
             $mockPath = 'TestPath'
@@ -283,6 +284,7 @@ try
                 ParentDomainName              = $mockParentDomainName
                 Credential                    = $mockAdministratorCredential
                 SafeModeAdministratorPassword = $mockSafemodeCredential
+                DomainType                    = $mockDomainType
             }
 
             Mock -CommandName Get-TargetResource -MockWith { return $mockADDomainAbsent }
@@ -385,7 +387,7 @@ try
                     Set-TargetResource @setTargetResourceDomainParams
 
                     Assert-MockCalled -CommandName Install-ADDSDomain `
-                        -ParameterFilter { $DomainType -eq 'ChildDomain' }
+                        -ParameterFilter { $DomainType -eq $mockDomainType }
                 }
 
                 It 'Calls "Install-ADDSDomain" with "SafeModeAdministratorPassword"' {


### PR DESCRIPTION
#### Pull Request (PR) description

ADDomain resource: Add DomainType support

NB I'm not sure if this is completely correct but am having a go anyway! In particular I couldn't find a way to 'get' the current DomainType for a domain so Get-TargetResource should just return $null - is that OK?

#### This Pull Request (PR) fixes the following issues

- Fixes #689
- Fixes #692 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ActiveDirectoryDsc/705)
<!-- Reviewable:end -->
