### PR TITLE
ADObjectPermissionEntry: Fix escaping issue when getting/setting ACLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 - ActiveDirectoryDsc.Common
   - Fixed Get-DomainControllerObject to allow checking non-local domain controller accounts.
+- ADObjectPermissionEntry
+  - Fixed 'The object name has a bad syntax' error when using path that requires escaping.
+    ([issue #675](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/675)).
 - Update build process to pin GitVersion to 5.* to resolve errors
   (https://github.com/gaelcolas/Sampler/issues/477).
 

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -83,8 +83,8 @@ function Get-TargetResource
 
     try
     {
-        # Get the current acl
-        $acl = Get-Acl -Path "AD:$Path" -ErrorAction Stop
+        # Get the current acl - include workaround for escaping paths https://github.com/dsccommunity/ActiveDirectoryDsc/issues/675
+        $acl = Get-Acl -Path "Microsoft.ActiveDirectory.Management.dll\ActiveDirectory:://RootDSE/$Path" -ErrorAction Stop
     }
     catch [System.Management.Automation.ItemNotFoundException]
     {
@@ -209,8 +209,8 @@ function Set-TargetResource
 
     Assert-ADPSDrive
 
-    # Get the current acl
-    $acl = Get-Acl -Path "AD:$Path"
+    # Get the current acl - include workaround for escaping paths https://github.com/dsccommunity/ActiveDirectoryDsc/issues/675
+    $acl = Get-Acl -Path "Microsoft.ActiveDirectory.Management.dll\ActiveDirectory:://RootDSE/$Path"
 
     if ($Ensure -eq 'Present')
     {
@@ -253,9 +253,9 @@ function Set-TargetResource
         }
     }
 
-    # Set the updated acl to the object
+    # Set the updated acl to the object - include workaround for escaping paths https://github.com/dsccommunity/ActiveDirectoryDsc/issues/675
     $acl |
-        Set-Acl -Path "AD:$Path"
+        Set-Acl -Path "Microsoft.ActiveDirectory.Management.dll\ActiveDirectory:://RootDSE/$Path"
 }
 
 <#

--- a/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -58,7 +58,7 @@ try
 
         $mockGetAclPresent = {
             $mock = [PSCustomObject] @{
-                Path   = 'AD:CN=PC01,CN=Computers,DC=contoso,DC=com'
+                Path   = 'Microsoft.ActiveDirectory.Management.dll\ActiveDirectory:://RootDSE/CN=PC01,CN=Computers,DC=contoso,DC=com'
                 Owner  = 'BUILTIN\Administrators'
                 Access = @(
                     [PSCustomObject] @{
@@ -84,7 +84,7 @@ try
 
         $mockGetAclAbsent = {
             $mock = [PSCustomObject] @{
-                Path   = 'AD:CN=PC,CN=Computers,DC=lab,DC=local'
+                Path   = 'Microsoft.ActiveDirectory.Management.dll\ActiveDirectory:://RootDSE/CN=PC,CN=Computers,DC=lab,DC=local'
                 Owner  = 'BUILTIN\Administrators'
                 Access = @()
             }


### PR DESCRIPTION
#### Pull Request (PR) description

Fixes #675 - when using ADObjectPermissionEntry to configure an ACL on a Path that requires escaping (comma, backslash, hash, plus etc), the command fails with 'The object name has bad syntax'

#### This Pull Request (PR) fixes the following issues

- Fixes #675

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ActiveDirectoryDsc/716)
<!-- Reviewable:end -->
