### PR TITLE
ADManagedServiceAccount: Fixed KeberosEncryptionType and TrustedForDelegation on account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Fixed
+- ADmanagedServiceAccount
+  - Set properties KeberosEncryptionType and TrustedForDelegation properly on account creation.
+    Both properties were not considered previously when the account was created.
+    ([issue #650](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/650)).
+
 ## [6.6.0] - 2024-09-29
 
 ### Added

--- a/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
+++ b/source/DSCResources/MSFT_ADManagedServiceAccount/MSFT_ADManagedServiceAccount.psm1
@@ -717,9 +717,19 @@ function Set-TargetResource
                 $newAdServiceAccountParameters.DisplayName = $DisplayName
             }
 
+            if ($parameters.ContainsKey('KerberosEncryptionType'))
+            {
+                $newAdServiceAccountParameters.KerberosEncryptionType = $KerberosEncryptionType
+            }
+
             if ($parameters.ContainsKey('Path'))
             {
                 $newAdServiceAccountParameters.Path = $Path
+            }
+
+            if ($parameters.ContainsKey('TrustedForDelegation'))
+            {
+                $newAdServiceAccountParameters.TrustedForDelegation = $TrustedForDelegation
             }
 
             if ( $AccountType -eq 'Standalone' )

--- a/tests/Unit/MSFT_ADManagedServiceAccount.Tests.ps1
+++ b/tests/Unit/MSFT_ADManagedServiceAccount.Tests.ps1
@@ -94,6 +94,7 @@ try
             ManagedPasswordPrincipals = @()
             MembershipAttribute       = $mockAdServiceAccountStandalone.MembershipAttribute
             KerberosEncryptionType    = @()
+            TrustedForDelegation      = $null
             Ensure                    = 'Absent'
         }
 
@@ -102,6 +103,7 @@ try
             Description               = 'Changed description'
             DisplayName               = 'Changed displayname'
             KerberosEncryptionType    = 'AES128', 'AES256'
+            TrustedForDelegation      = $true
             ManagedPasswordPrincipals = $mockADUSer.SamAccountName
         }
 
@@ -434,6 +436,7 @@ try
                 Description               = $mockAdServiceAccountStandalone.Description
                 DisplayName               = $mockAdServiceAccountStandalone.DisplayName
                 KerberosEncryptionType    = $mockAdServiceAccountStandalone.KerberosEncryptionType
+                TrustedForDelegation      = $mockAdServiceAccountStandalone.TrustedForDelegation
                 ManagedPasswordPrincipals = $mockAdServiceAccountStandalone.ManagedPasswordPrincipals
                 MembershipAttribute       = $mockAdServiceAccountStandalone.MembershipAttribute
                 Ensure                    = $mockAdServiceAccountStandalone.Ensure
@@ -567,6 +570,7 @@ try
                 Ensure                 = $mockAdServiceAccountStandAlone.Ensure
                 DisplayName            = $mockAdServiceAccountStandAlone.DisplayName
                 KerberosEncryptionType = $mockAdServiceAccountStandAlone.KerberosEncryptionType
+                TrustedForDelegation   = $mockAdServiceAccountStandAlone.TrustedForDelegation
             }
 
             $setTargetResourceParametersStandAloneAbsent = $setTargetResourceParametersStandAlone.Clone()
@@ -583,6 +587,7 @@ try
                 ManagedPasswordPrincipals = $mockAdServiceAccountGroup.ManagedPasswordPrincipals
                 DisplayName               = $mockAdServiceAccountGroup.Name.DisplayName
                 KerberosEncryptionType    = $mockAdServiceAccountGroup.KerberosEncryptionType
+                TrustedForDelegation      = $mockAdServiceAccountGroup.TrustedForDelegation
             }
             Context 'When the Resource should be Present' {
 


### PR DESCRIPTION
#### Pull Request (PR) description
ADManagedServiceAccount: Set properties KeberosEncryptionType and TrustedForDelegation properly on account creation.
Both properties were not considered previously when the account was created.

#### This Pull Request (PR) fixes the following issues
- Fixes #650

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ActiveDirectoryDsc/722)
<!-- Reviewable:end -->
