### PR TITLE
ADObjectPermissionEntry: Resolve Windows Server 2016 PSPath issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Fixed
+
+- ADObjectPermissionEntry
+  - Fixed regression where resource cannot run on Windows Server 2016
+    ([issue #724])(https://github.com/dsccommunity/ActiveDirectoryDsc/issues/724)).
+
 ## [6.6.0] - 2024-09-29
 
 ### Added

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -390,8 +390,8 @@ function Get-ADDrivePSPath
     [OutputType([System.String])]
     param ()
 
-    # Need to use the full PSPath to avoid issues when escaping paths - see https://github.com/dsccommunity/ActiveDirectoryDsc/issues/675
-    # The full PSPath varies between operating systems, so we obtain it dynamically https://github.com/dsccommunity/ActiveDirectoryDsc/issues/724
+    # Need to use the full PSPath to avoid issues when escaping paths - https://github.com/dsccommunity/ActiveDirectoryDsc/issues/675
+    # The full PSPath varies between operating systems, so we obtain it dynamically - https://github.com/dsccommunity/ActiveDirectoryDsc/issues/724
 
     $adDrivePSPath = (Get-Item -Path 'AD:\').PSPath
     Write-Verbose -Message ($script:localizedData.RetrievedADDrivePSPath -f $adDrivePSPath)

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -67,7 +67,6 @@ function Get-TargetResource
         $InheritedObjectType
     )
 
-    Assert-ADPSDrive
     $ADDrivePSPath = Get-ADDrivePSPath
 
     # Return object, by default representing an absent ace
@@ -208,7 +207,6 @@ function Set-TargetResource
         $InheritedObjectType
     )
 
-    Assert-ADPSDrive
     $ADDrivePSPath = Get-ADDrivePSPath
 
     # Get the current acl
@@ -393,7 +391,9 @@ function Get-ADDrivePSPath
     # Need to use the full PSPath to avoid issues when escaping paths - https://github.com/dsccommunity/ActiveDirectoryDsc/issues/675
     # The full PSPath varies between operating systems, so we obtain it dynamically - https://github.com/dsccommunity/ActiveDirectoryDsc/issues/724
 
-    $adDrivePSPath = (Get-Item -Path 'AD:\').PSPath
+    Assert-ADPSDrive
+
+    $adDrivePSPath = (Get-Item -Path 'AD:').PSPath
     Write-Verbose -Message ($script:localizedData.RetrievedADDrivePSPath -f $adDrivePSPath)
     return $adDrivePSPath
 }

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -390,7 +390,8 @@ function Get-ADDrivePSPath
     [OutputType([System.String])]
     param ()
 
-    # See https://github.com/dsccommunity/ActiveDirectoryDsc/issues/724
+    # Need to use the full PSPath to avoid issues when escaping paths - see https://github.com/dsccommunity/ActiveDirectoryDsc/issues/675
+    # The full PSPath varies between operating systems, so we obtain it dynamically https://github.com/dsccommunity/ActiveDirectoryDsc/issues/724
 
     $adDrivePSPath = (Get-Item -Path 'AD:\').PSPath
     Write-Verbose -Message ($script:localizedData.RetrievedADDrivePSPath -f $adDrivePSPath)

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -84,7 +84,7 @@ function Get-TargetResource
     try
     {
         # Get the current acl
-        $acl = Get-Acl -Path "$ADDrivePSPath$Path" -ErrorAction Stop
+        $acl = Get-Acl -Path (Join-Path -Path $ADDrivePSPath -ChildPath $Path) -ErrorAction Stop
     }
     catch [System.Management.Automation.ItemNotFoundException]
     {
@@ -210,7 +210,7 @@ function Set-TargetResource
     $ADDrivePSPath = Get-ADDrivePSPath
 
     # Get the current acl
-    $acl = Get-Acl -Path "$ADDrivePSPath$Path"
+    $acl = Get-Acl -Path (Join-Path -Path $ADDrivePSPath -ChildPath $Path)
 
     if ($Ensure -eq 'Present')
     {
@@ -255,7 +255,7 @@ function Set-TargetResource
 
     # Set the updated acl to the object
     $acl |
-        Set-Acl -Path "$ADDrivePSPath$Path"
+        Set-Acl -Path (Join-Path -Path $ADDrivePSPath -ChildPath $Path)
 }
 
 <#

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/en-US/MSFT_ADObjectPermissionEntry.strings.psd1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/en-US/MSFT_ADObjectPermissionEntry.strings.psd1
@@ -8,5 +8,5 @@ ConvertFrom-StringData @'
     ObjectPermissionEntryInDesiredState    = Object permission entry on object '{0}' is in the desired state. (OPE0005)
     ObjectPermissionEntryNotInDesiredState = Object permission entry on object '{0}' is not in the desired state. (OPE0006)
     ObjectPathIsAbsent                     = Object Path '{0}' is absent from Active Directory. (OPE0007)
-    RetrievedADDrivePSPat                  = Retrieved the AD Drive full PSPath of '{0}'. (OPE0008)
+    RetrievedADDrivePSPath                 = Retrieved the AD Drive full PSPath of '{0}'. (OPE0008)
 '@

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/en-US/MSFT_ADObjectPermissionEntry.strings.psd1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/en-US/MSFT_ADObjectPermissionEntry.strings.psd1
@@ -8,4 +8,5 @@ ConvertFrom-StringData @'
     ObjectPermissionEntryInDesiredState    = Object permission entry on object '{0}' is in the desired state. (OPE0005)
     ObjectPermissionEntryNotInDesiredState = Object permission entry on object '{0}' is not in the desired state. (OPE0006)
     ObjectPathIsAbsent                     = Object Path '{0}' is absent from Active Directory. (OPE0007)
+    RetrievedADDrivePSPat                  = Retrieved the AD Drive full PSPath of '{0}'. (OPE0008)
 '@

--- a/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -56,6 +56,8 @@ try
             ActiveDirectoryRights = 'GenericAll'
         }
 
+        $mockADDrivePSPath = 'Microsoft.ActiveDirectory.Management.dll\ActiveDirectory:://RootDSE/'
+
         $mockGetAclPresent = {
             $mock = [PSCustomObject] @{
                 Path   = 'Microsoft.ActiveDirectory.Management.dll\ActiveDirectory:://RootDSE/CN=PC01,CN=Computers,DC=contoso,DC=com'
@@ -96,16 +98,13 @@ try
 
         #region Function Get-TargetResource
         Describe 'ADObjectPermissionEntry\Get-TargetResource' {
-            Mock -CommandName 'Assert-ADPSDrive'
+            Mock -CommandName 'Get-ADDrivePSPath' -MockWith {
+                return $mockADDrivePSPath
+            }
 
             Context 'When the desired ace is present' {
 
                 Mock -CommandName 'Get-Acl' -MockWith $mockGetAclPresent
-
-                It 'Should call "Assert-ADPSDrive" to check AD PS Drive is created' {
-                    $targetResource = Get-TargetResource @testDefaultParameters
-                    Assert-MockCalled -CommandName Assert-ADPSDrive -Scope It -Exactly -Times 1
-                }
 
                 It 'Should return a "System.Collections.Hashtable" object type' {
                     # Act
@@ -134,11 +133,6 @@ try
             Context 'When the desired ace is absent' {
 
                 Mock -CommandName 'Get-Acl' -MockWith $mockGetAclAbsent
-
-                It 'Should call "Assert-ADPSDrive" to check AD PS Drive is created' {
-                    $targetResource = Get-TargetResource @testDefaultParameters
-                    Assert-MockCalled -CommandName Assert-ADPSDrive -Scope It -Exactly -Times 1
-                }
 
                 It 'Should return a valid result if the ace is absent' {
                     # Act
@@ -180,7 +174,6 @@ try
 
         #region Function Test-TargetResource
         Describe 'ADObjectPermissionEntry\Test-TargetResource' {
-            Mock -CommandName 'Assert-ADPSDrive' { }
 
             Context 'When the desired ace is present' {
 
@@ -236,17 +229,14 @@ try
 
         #region Function Set-TargetResource
         Describe 'ADObjectPermissionEntry\Set-TargetResource' {
-            Mock -CommandName 'Assert-ADPSDrive'
+            Mock -CommandName 'Get-ADDrivePSPath' -MockWith {
+                return $mockADDrivePSPath
+            }
 
             Context 'When the desired ace is present' {
 
                 Mock -CommandName 'Get-Acl' -MockWith $mockGetAclPresent
                 Mock -CommandName 'Set-Acl' -Verifiable
-
-                It 'Should call "Assert-ADPSDrive" to check AD PS Drive is created' {
-                    $targetResource = Get-TargetResource @testDefaultParameters
-                    Assert-MockCalled -CommandName Assert-ADPSDrive -Scope It -Exactly -Times 1
-                }
 
                 It 'Should remove the ace from the existing acl' {
                     # Act
@@ -261,11 +251,6 @@ try
 
                 Mock -CommandName 'Get-Acl' -MockWith $mockGetAclAbsent
                 Mock -CommandName 'Set-Acl' -Verifiable
-
-                It 'Should call "Assert-ADPSDrive" to check AD PS Drive is created' {
-                    $targetResource = Get-TargetResource @testDefaultParameters
-                    Assert-MockCalled -CommandName Assert-ADPSDrive -Scope It -Exactly -Times 1
-                }
 
                 It 'Should add the ace to the existing acl' {
                     # Act

--- a/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -56,7 +56,7 @@ try
             ActiveDirectoryRights = 'GenericAll'
         }
 
-        $mockADDrivePSPath = '/'
+        $mockADDrivePSPath = '\'
 
         $mockGetAclPresent = {
             $mock = [PSCustomObject] @{

--- a/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -56,7 +56,7 @@ try
             ActiveDirectoryRights = 'GenericAll'
         }
 
-        $mockADDrivePSPath = 'Microsoft.ActiveDirectory.Management.dll\ActiveDirectory:://RootDSE/'
+        $mockADDrivePSPath = '/'
 
         $mockGetAclPresent = {
             $mock = [PSCustomObject] @{

--- a/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -174,6 +174,9 @@ try
 
         #region Function Test-TargetResource
         Describe 'ADObjectPermissionEntry\Test-TargetResource' {
+            Mock -CommandName 'Get-ADDrivePSPath' -MockWith {
+                return $mockADDrivePSPath
+            }
 
             Context 'When the desired ace is present' {
 

--- a/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -96,6 +96,26 @@ try
         }
         #endregion
 
+        #region Function Get-ADDrivePSPath
+        Describe -Name 'ADObjectPermissionEntry\Get-ADDrivePSPath' {
+            Mock -CommandName 'Assert-ADPSDrive'
+            Mock -CommandName Get-Item -MockWith {
+                return @{
+                    PSPath = $mockADDrivePSPath
+                }
+            }
+
+            It 'Should call "Assert-ADPSDrive" to check AD PS Drive is created' {
+                Get-ADDrivePSPath
+                Assert-MockCalled -CommandName Assert-ADPSDrive -Scope It -Exactly -Times 1
+            }
+
+            It 'Should return domain distinguished name' {
+                Get-ADDrivePSPath | Should -Be $mockADDrivePSPath
+            }
+        }
+        #endregion Function Get-ADDrivePSPath
+
         #region Function Get-TargetResource
         Describe 'ADObjectPermissionEntry\Get-TargetResource' {
             Mock -CommandName 'Get-ADDrivePSPath' -MockWith {

--- a/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -106,12 +106,19 @@ try
             }
 
             It 'Should call "Assert-ADPSDrive" to check AD PS Drive is created' {
-                Get-ADDrivePSPath
+                # Act
+                $ADDrivePSPath = Get-ADDrivePSPath
+
+                # Assert
                 Assert-MockCalled -CommandName Assert-ADPSDrive -Scope It -Exactly -Times 1
             }
 
-            It 'Should return domain distinguished name' {
-                Get-ADDrivePSPath | Should -Be $mockADDrivePSPath
+            It 'Should return full PSPath for the AD Drive' {
+                # Act
+                $ADDrivePSPath = Get-ADDrivePSPath
+
+                # Assert
+                $ADDrivePSPath | Should -Be $mockADDrivePSPath
             }
         }
         #endregion Function Get-ADDrivePSPath


### PR DESCRIPTION
#### Pull Request (PR) description

Resolves the issue described in #724 where ADObjectPermissionEntry has stopped working on Server 2016 (still works on 2012, 2019, 2022, 2025).

#### This Pull Request (PR) fixes the following issues

- Fixes #724 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ActiveDirectoryDsc/725)
<!-- Reviewable:end -->
