### PR TITLE
ADObjectPermissionEntry: Fix regression in 6.6.1 using Join-Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Fixed
+ - ADObjectPermissionEntry
+   -Fixed regression in 6.6.1 when using Join-Path.
+   ([issue #727](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/727)).
+
 ## [6.6.1] - 2025-03-15
 
 ### Fixed
@@ -16,7 +21,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
     ([issue #650](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/650)).
 - ADObjectPermissionEntry
   - Fixed regression where resource cannot run on Windows Server 2016
-    ([issue #724])(https://github.com/dsccommunity/ActiveDirectoryDsc/issues/724)).
+    ([issue #724](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/724)).
 
 ## [6.6.0] - 2024-09-29
 

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -84,7 +84,7 @@ function Get-TargetResource
     try
     {
         # Get the current acl
-        $acl = Get-Acl -Path (Join-Path -Path $ADDrivePSPath -ChildPath $Path) -ErrorAction Stop
+        $acl = Get-Acl -Path ($ADDrivePSPath + $Path) -ErrorAction Stop
     }
     catch [System.Management.Automation.ItemNotFoundException]
     {
@@ -210,7 +210,7 @@ function Set-TargetResource
     $ADDrivePSPath = Get-ADDrivePSPath
 
     # Get the current acl
-    $acl = Get-Acl -Path (Join-Path -Path $ADDrivePSPath -ChildPath $Path)
+    $acl = Get-Acl -Path ($ADDrivePSPath + $Path)
 
     if ($Ensure -eq 'Present')
     {
@@ -255,7 +255,7 @@ function Set-TargetResource
 
     # Set the updated acl to the object
     $acl |
-        Set-Acl -Path (Join-Path -Path $ADDrivePSPath -ChildPath $Path)
+        Set-Acl -Path ($ADDrivePSPath + $Path)
 }
 
 <#


### PR DESCRIPTION
#### Pull Request (PR) description

Fixes regression uncovered in #727. We started using Join-Path but this doesn't work with the output of Get-ADDrivePSPath

#### This Pull Request (PR) fixes the following issues

- Fixes #727

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
