### PR TITLE
ADDomain, ADDomainFunctionalLevel, ADForestFunctionalLevel, ADUser - Server 2025 support, new attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Added
+- ADDomain
+  - Support for Windows Server 2025 Forest and Domain functional modes.
+    ([issue #721](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/721)).
+- ADDomainFunctionalLevel
+  - Support for Windows Server 2025 Domain functional mode.
+    ([issue #721](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/721)).
+- ADForestFunctionalLevel
+  - Support for Windows Server 2025 Forest functional mode.
+    ([issue #721](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/721)).
+- ADUser
+  - Support for AdminDescription, DisplayNamePrintable, PhoneticDisplayName
+    and PreferredLanguage attributes.
+
 ## [6.6.1] - 2025-03-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ### Fixed
  - ADObjectPermissionEntry
-   -Fixed regression in 6.6.1 when using Join-Path.
+   - Fixed regression in 6.6.1 when using Join-Path.
    ([issue #727](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/727)).
 
 ## [6.6.1] - 2025-03-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Support for Windows Server 2025 Forest functional mode.
     ([issue #721](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/721)).
 - ADUser
-  - Support for AdminDescription, DisplayNamePrintable, PhoneticDisplayName
-    and PreferredLanguage attributes.
+  - Support for AdminDescription, PhoneticDisplayName, PreferredLanguage and
+    SimpleDisplayName attributes.
 
 ### Fixed
  - ADObjectPermissionEntry

--- a/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
+++ b/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.psm1
@@ -277,12 +277,12 @@ function Test-TargetResource
         $SysvolPath,
 
         [Parameter()]
-        [ValidateSet('Win2008', 'Win2008R2', 'Win2012', 'Win2012R2', 'WinThreshold')]
+        [ValidateSet('Win2008', 'Win2008R2', 'Win2012', 'Win2012R2', 'WinThreshold', 'Win2025')]
         [System.String]
         $ForestMode,
 
         [Parameter()]
-        [ValidateSet('Win2008', 'Win2008R2', 'Win2012', 'Win2012R2', 'WinThreshold')]
+        [ValidateSet('Win2008', 'Win2008R2', 'Win2012', 'Win2012R2', 'WinThreshold', 'Win2025')]
         [System.String]
         $DomainMode
     )
@@ -435,12 +435,12 @@ function Set-TargetResource
         $SysvolPath,
 
         [Parameter()]
-        [ValidateSet('Win2008', 'Win2008R2', 'Win2012', 'Win2012R2', 'WinThreshold')]
+        [ValidateSet('Win2008', 'Win2008R2', 'Win2012', 'Win2012R2', 'WinThreshold', 'Win2025')]
         [System.String]
         $ForestMode,
 
         [Parameter()]
-        [ValidateSet('Win2008', 'Win2008R2', 'Win2012', 'Win2012R2', 'WinThreshold')]
+        [ValidateSet('Win2008', 'Win2008R2', 'Win2012', 'Win2012R2', 'WinThreshold', 'Win2025')]
         [System.String]
         $DomainMode
     )

--- a/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.schema.mof
+++ b/source/DSCResources/MSFT_ADDomain/MSFT_ADDomain.schema.mof
@@ -11,8 +11,8 @@ class MSFT_ADDomain : OMI_BaseResource
     [Write, Description("Path to a directory that contains the domain database.")] String DatabasePath;
     [Write, Description("Path to a directory for the log file that will be written.")] String LogPath;
     [Write, Description("Path to a directory where the Sysvol file will be written.")] String SysvolPath;
-    [Write, Description("The Forest Functional Level for the entire forest."), ValueMap{"Win2008", "Win2008R2", "Win2012", "Win2012R2", "WinThreshold"}, Values{"Win2008", "Win2008R2", "Win2012", "Win2012R2", "WinThreshold"}] String ForestMode;
-    [Write, Description("The Domain Functional Level for the entire domain."), ValueMap{"Win2008", "Win2008R2", "Win2012", "Win2012R2", "WinThreshold"}, Values{"Win2008", "Win2008R2", "Win2012", "Win2012R2", "WinThreshold"}] String DomainMode;
+    [Write, Description("The Forest Functional Level for the entire forest."), ValueMap{"Win2008", "Win2008R2", "Win2012", "Win2012R2", "WinThreshold", "Win2025"}, Values{"Win2008", "Win2008R2", "Win2012", "Win2012R2", "WinThreshold", "Win2025"}] String ForestMode;
+    [Write, Description("The Domain Functional Level for the entire domain."), ValueMap{"Win2008", "Win2008R2", "Win2012", "Win2012R2", "WinThreshold", "Win2025"}, Values{"Win2008", "Win2008R2", "Win2012", "Win2012R2", "WinThreshold", "Win2025"}] String DomainMode;
     [Read, Description("Returns $true if the domain is available, or $false if the domain could not be found.")] Boolean DomainExist;
     [Read, Description("Returns the fully qualified domain name (FQDN) DNS root of the domain.")] String DnsRoot;
     [Read, Description("Returns the fully qualified domain name (FQDN) of the forest.")] String Forest;

--- a/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
+++ b/source/DSCResources/MSFT_ADDomain/en-US/about_ADDomain.help.txt
@@ -51,12 +51,12 @@
 
 .PARAMETER ForestMode
     Write - String
-    Allowed values: Win2008, Win2008R2, Win2012, Win2012R2, WinThreshold
+    Allowed values: Win2008, Win2008R2, Win2012, Win2012R2, WinThreshold, Win2025
     The Forest Functional Level for the entire forest.
 
 .PARAMETER DomainMode
     Write - String
-    Allowed values: Win2008, Win2008R2, Win2012, Win2012R2, WinThreshold
+    Allowed values: Win2008, Win2008R2, Win2012, Win2012R2, WinThreshold, Win2025
     The Domain Functional Level for the entire domain.
 
 .PARAMETER DomainExist

--- a/source/DSCResources/MSFT_ADDomainFunctionalLevel/MSFT_ADDomainFunctionalLevel.psm1
+++ b/source/DSCResources/MSFT_ADDomainFunctionalLevel/MSFT_ADDomainFunctionalLevel.psm1
@@ -34,7 +34,7 @@ function Get-TargetResource
         $DomainIdentity,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Windows2008R2Domain', 'Windows2012Domain', 'Windows2012R2Domain', 'Windows2016Domain')]
+        [ValidateSet('Windows2008R2Domain', 'Windows2012Domain', 'Windows2012R2Domain', 'Windows2016Domain', 'Windows2025Domain')]
         [System.String]
         $DomainMode
     )
@@ -78,7 +78,7 @@ function Test-TargetResource
         $DomainIdentity,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Windows2008R2Domain', 'Windows2012Domain', 'Windows2012R2Domain', 'Windows2016Domain')]
+        [ValidateSet('Windows2008R2Domain', 'Windows2012Domain', 'Windows2012R2Domain', 'Windows2016Domain', 'Windows2025Domain')]
         [System.String]
         $DomainMode
     )
@@ -127,7 +127,7 @@ function Set-TargetResource
         $DomainIdentity,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Windows2008R2Domain', 'Windows2012Domain', 'Windows2012R2Domain', 'Windows2016Domain')]
+        [ValidateSet('Windows2008R2Domain', 'Windows2012Domain', 'Windows2012R2Domain', 'Windows2016Domain', 'Windows2025Domain')]
         [System.String]
         $DomainMode
     )
@@ -180,7 +180,7 @@ function Compare-TargetResourceState
         $DomainIdentity,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Windows2008R2Domain', 'Windows2012Domain', 'Windows2012R2Domain', 'Windows2016Domain')]
+        [ValidateSet('Windows2008R2Domain', 'Windows2012Domain', 'Windows2012R2Domain', 'Windows2016Domain', 'Windows2025Domain')]
         [System.String]
         $DomainMode
     )

--- a/source/DSCResources/MSFT_ADDomainFunctionalLevel/MSFT_ADDomainFunctionalLevel.schema.mof
+++ b/source/DSCResources/MSFT_ADDomainFunctionalLevel/MSFT_ADDomainFunctionalLevel.schema.mof
@@ -2,5 +2,5 @@
 class MSFT_ADDomainFunctionalLevel : OMI_BaseResource
 {
     [Key, Description("Specifies the Active Directory domain to modify. You can identify a domain by its distinguished name, GUID, security identifier, DNS domain name, or NetBIOS domain name.")] String DomainIdentity;
-    [Required, Description("Specifies the functional level for the Active Directory domain."), ValueMap{"Windows2008R2Domain", "Windows2012Domain", "Windows2012R2Domain", "Windows2016Domain"}, Values{"Windows2008R2Domain", "Windows2012Domain", "Windows2012R2Domain", "Windows2016Domain"}] String DomainMode;
+    [Required, Description("Specifies the functional level for the Active Directory domain."), ValueMap{"Windows2008R2Domain", "Windows2012Domain", "Windows2012R2Domain", "Windows2016Domain", "Windows2025Domain"}, Values{"Windows2008R2Domain", "Windows2012Domain", "Windows2012R2Domain", "Windows2016Domain", "Windows2025Domain"}] String DomainMode;
 };

--- a/source/DSCResources/MSFT_ADDomainFunctionalLevel/en-US/about_ADDomainFunctionalLevel.help.txt
+++ b/source/DSCResources/MSFT_ADDomainFunctionalLevel/en-US/about_ADDomainFunctionalLevel.help.txt
@@ -22,7 +22,7 @@
 
 .PARAMETER DomainMode
     Required - String
-    Allowed values: Windows2008R2Domain, Windows2012Domain, Windows2012R2Domain, Windows2016Domain
+    Allowed values: Windows2008R2Domain, Windows2012Domain, Windows2012R2Domain, Windows2016Domain, Windows2025Domain
     Specifies the functional level for the Active Directory domain.
 
 .EXAMPLE 1
@@ -43,5 +43,3 @@ Configuration ADDomainFunctionalLevel_SetLevel_Config
         }
     }
 }
-
-

--- a/source/DSCResources/MSFT_ADForestFunctionalLevel/MSFT_ADForestFunctionalLevel.psm1
+++ b/source/DSCResources/MSFT_ADForestFunctionalLevel/MSFT_ADForestFunctionalLevel.psm1
@@ -34,7 +34,7 @@ function Get-TargetResource
         $ForestIdentity,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Windows2008R2Forest', 'Windows2012Forest', 'Windows2012R2Forest', 'Windows2016Forest')]
+        [ValidateSet('Windows2008R2Forest', 'Windows2012Forest', 'Windows2012R2Forest', 'Windows2016Forest', 'Windows2025Forest')]
         [System.String]
         $ForestMode
     )
@@ -77,7 +77,7 @@ function Test-TargetResource
         $ForestIdentity,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Windows2008R2Forest', 'Windows2012Forest', 'Windows2012R2Forest', 'Windows2016Forest')]
+        [ValidateSet('Windows2008R2Forest', 'Windows2012Forest', 'Windows2012R2Forest', 'Windows2016Forest', 'Windows2025Forest')]
         [System.String]
         $ForestMode
     )
@@ -126,7 +126,7 @@ function Set-TargetResource
         $ForestIdentity,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Windows2008R2Forest', 'Windows2012Forest', 'Windows2012R2Forest', 'Windows2016Forest')]
+        [ValidateSet('Windows2008R2Forest', 'Windows2012Forest', 'Windows2012R2Forest', 'Windows2016Forest', 'Windows2025Forest')]
         [System.String]
         $ForestMode
     )
@@ -179,7 +179,7 @@ function Compare-TargetResourceState
         $ForestIdentity,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Windows2008R2Forest', 'Windows2012Forest', 'Windows2012R2Forest', 'Windows2016Forest')]
+        [ValidateSet('Windows2008R2Forest', 'Windows2012Forest', 'Windows2012R2Forest', 'Windows2016Forest', 'Windows2025Forest')]
         [System.String]
         $ForestMode
     )

--- a/source/DSCResources/MSFT_ADForestFunctionalLevel/MSFT_ADForestFunctionalLevel.schema.mof
+++ b/source/DSCResources/MSFT_ADForestFunctionalLevel/MSFT_ADForestFunctionalLevel.schema.mof
@@ -2,5 +2,5 @@
 class MSFT_ADForestFunctionalLevel : OMI_BaseResource
 {
     [Key, Description("Specifies the Active Directory forest to modify. You can identify a forest by its fully qualified domain name (FQDN), GUID, DNS host name, or NetBIOS name.")] String ForestIdentity;
-    [Required, Description("Specifies the the functional level for the Active Directory forest."), ValueMap{"Windows2008R2Forest", "Windows2012Forest", "Windows2012R2Forest", "Windows2016Forest"}, Values{"Windows2008R2Forest", "Windows2012Forest", "Windows2012R2Forest", "Windows2016Forest"}] String ForestMode;
+    [Required, Description("Specifies the the functional level for the Active Directory forest."), ValueMap{"Windows2008R2Forest", "Windows2012Forest", "Windows2012R2Forest", "Windows2016Forest", "Windows2025Forest"}, Values{"Windows2008R2Forest", "Windows2012Forest", "Windows2012R2Forest", "Windows2016Forest", "Windows2025Forest"}] String ForestMode;
 };

--- a/source/DSCResources/MSFT_ADForestFunctionalLevel/en-US/about_ADForestFunctionalLevel.help.txt
+++ b/source/DSCResources/MSFT_ADForestFunctionalLevel/en-US/about_ADForestFunctionalLevel.help.txt
@@ -22,7 +22,7 @@
 
 .PARAMETER ForestMode
     Required - String
-    Allowed values: Windows2008R2Forest, Windows2012Forest, Windows2012R2Forest, Windows2016Forest
+    Allowed values: Windows2008R2Forest, Windows2012Forest, Windows2012R2Forest, Windows2016Forest, Windows2025Forest
     Specifies the the functional level for the Active Directory forest.
 
 .EXAMPLE 1
@@ -43,5 +43,3 @@ Configuration ADForestFunctionalLevel_SetLevel_Config
         }
     }
 }
-
-

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.PropertyMap.psd1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.PropertyMap.psd1
@@ -306,5 +306,29 @@
             UseCmdletParameter = $false
             Array              = $true
         }
+        @{
+            Parameter          = 'AdminDescription'
+            ADProperty         = 'adminDescription'
+            UseCmdletParameter = $false
+            Array              = $false
+        }
+        @{
+            Parameter          = 'DisplayNamePrintable'
+            ADProperty         = 'displayNamePrintable'
+            UseCmdletParameter = $false
+            Array              = $false
+        }
+        @{
+            Parameter          = 'PhoneticDisplayName'
+            ADProperty         = 'msDS-PhoneticDisplayName'
+            UseCmdletParameter = $false
+            Array              = $false
+        }
+        @{
+            Parameter          = 'PreferredLanguage'
+            ADProperty         = 'preferredLanguage'
+            UseCmdletParameter = $false
+            Array              = $false
+        }
     )
 }

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.PropertyMap.psd1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.PropertyMap.psd1
@@ -313,12 +313,6 @@
             Array              = $false
         }
         @{
-            Parameter          = 'DisplayNamePrintable'
-            ADProperty         = 'displayNamePrintable'
-            UseCmdletParameter = $false
-            Array              = $false
-        }
-        @{
             Parameter          = 'PhoneticDisplayName'
             ADProperty         = 'msDS-PhoneticDisplayName'
             UseCmdletParameter = $false
@@ -327,6 +321,12 @@
         @{
             Parameter          = 'PreferredLanguage'
             ADProperty         = 'preferredLanguage'
+            UseCmdletParameter = $false
+            Array              = $false
+        }
+        @{
+            Parameter          = 'SimpleDisplayName'
+            ADProperty         = 'displayNamePrintable'
             UseCmdletParameter = $false
             Array              = $false
         }

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -384,6 +384,21 @@ function Get-TargetResource
         be removed. The property ThumbnailPhoto will always return the image as a Base64-encoded string even if the
         configuration specified a file path.
 
+    .PARAMETER AdminDescription
+        Specifies the description displayed on admin screens. Can be set to User_ to filter out an user from
+        Entra ID Connect synchronization.
+
+    .PARAMETER DisplayNamePrintable
+        Specifies the printable display name for an object. Can be set to a different display name to be used
+        externally.
+
+    .PARAMETER PhoneticDisplayName
+        The phonetic display name of an object. In the absence of a phonetic display name, the existing display name
+        is used. (ldapDisplayName 'msDS-PhoneticDisplayName').
+
+    .PARAMETER PreferredLanguage
+        The preferred written or spoken language for a person. For Microsoft 365, should follow ISO 639-1 Code, for example, en-US.
+
     .NOTES
         Used Functions:
             Name                   | Module
@@ -1067,6 +1082,21 @@ function Test-TargetResource
         .jpg-file, or to a Base64-encoded jpeg image. If set to an empty string ('') the current thumbnail photo will
         be removed. The property ThumbnailPhoto will always return the image as a Base64-encoded string even if the
         configuration specified a file path.
+
+    .PARAMETER AdminDescription
+        Specifies the description displayed on admin screens. Can be set to User_ to filter out an user from
+        Entra ID Connect synchronization.
+
+    .PARAMETER DisplayNamePrintable
+        Specifies the printable display name for an object. Can be set to a different display name to be used
+        externally.
+
+    .PARAMETER PhoneticDisplayName
+        The phonetic display name of an object. In the absence of a phonetic display name, the existing display name
+        is used. (ldapDisplayName 'msDS-PhoneticDisplayName').
+
+    .PARAMETER PreferredLanguage
+        The preferred written or spoken language for a person. For Microsoft 365, should follow ISO 639-1 Code, for example, en-US.
 
     .NOTES
         Used Functions:

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -388,16 +388,16 @@ function Get-TargetResource
         Specifies the description displayed on admin screens. Can be set to User_ to filter out an user from
         Entra ID Connect synchronization.
 
-    .PARAMETER DisplayNamePrintable
-        Specifies the printable display name for an object. Can be set to a different display name to be used
-        externally.
-
     .PARAMETER PhoneticDisplayName
         The phonetic display name of an object. In the absence of a phonetic display name, the existing display name
         is used. (ldapDisplayName 'msDS-PhoneticDisplayName').
 
     .PARAMETER PreferredLanguage
         The preferred written or spoken language for a person. For Microsoft 365, should follow ISO 639-1 Code, for example, en-US.
+
+    .PARAMETER SimpleDisplayName
+        Specifies the printable display name for an object. Can be set to a different display name to be used
+        externally. (ldapDisplayName 'displayNamePrintable').
 
     .NOTES
         Used Functions:
@@ -1087,16 +1087,16 @@ function Test-TargetResource
         Specifies the description displayed on admin screens. Can be set to User_ to filter out an user from
         Entra ID Connect synchronization.
 
-    .PARAMETER DisplayNamePrintable
-        Specifies the printable display name for an object. Can be set to a different display name to be used
-        externally.
-
     .PARAMETER PhoneticDisplayName
         The phonetic display name of an object. In the absence of a phonetic display name, the existing display name
         is used. (ldapDisplayName 'msDS-PhoneticDisplayName').
 
     .PARAMETER PreferredLanguage
         The preferred written or spoken language for a person. For Microsoft 365, should follow ISO 639-1 Code, for example, en-US.
+
+    .PARAMETER SimpleDisplayName
+        Specifies the printable display name for an object. Can be set to a different display name to be used
+        externally. (ldapDisplayName 'displayNamePrintable').
 
     .NOTES
         Used Functions:

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -710,7 +710,27 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
-        $ThumbnailPhoto
+        $ThumbnailPhoto,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $AdminDescription,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $PhoneticDisplayName,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $PreferredLanguage,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $SimpleDisplayName
     )
 
     <#
@@ -1418,7 +1438,27 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
-        $ThumbnailPhoto
+        $ThumbnailPhoto,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $AdminDescription,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $PhoneticDisplayName,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $PreferredLanguage,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $SimpleDisplayName
     )
 
     <#

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
@@ -62,9 +62,9 @@ class MSFT_ADUser : OMI_BaseResource
     [Write, Description("Specifies whether a smart card is required to logon. This parameter sets the SmartCardLoginRequired property for a user object. This parameter also sets the ADS_UF_SMARTCARD_REQUIRED flag of the Active Directory User Account Control attribute.")] Boolean SmartcardLogonRequired;
     [Write, Description("Specifies the thumbnail photo to be used for the user object. Can be set either to a path pointing to a .jpg-file, or to a Base64-encoded jpeg image. If set to an empty string ('') the current thumbnail photo will be removed. The property ThumbnailPhoto will always return the image as a Base64-encoded string even if the configuration specified a file path.")] String ThumbnailPhoto;
     [Write, Description("Specifies the description displayed on admin screens. Can be set to User_ to filter out an user from Entra ID Connect synchronization.")] String AdminDescription;
-    [Write, Description("Specifies the printable display name for an object. Can be set to a different display name to be used externally.")] String DisplayNamePrintable;
     [Write, Description("The phonetic display name of an object. In the absence of a phonetic display name, the existing display name is used. (ldapDisplayName 'msDS-PhoneticDisplayName').")] String PhoneticDisplayName;
     [Write, Description("The preferred written or spoken language for a person. For Microsoft 365, should follow ISO 639-1 Code, for example, en-US.")] String PreferredLanguage;
+    [Write, Description("Specifies the printable display name for an object. Can be set to a different display name to be used externally. (ldapDisplayName 'displayNamePrintable').")] String SimpleDisplayName;
     [Read, Description("Returns the X.500 path of the object.")] String DistinguishedName;
     [Read, Description("Return the MD5 hash of the current thumbnail photo, or $null if no thumbnail photo exist.")] String ThumbnailPhotoHash;
 };

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
@@ -61,6 +61,10 @@ class MSFT_ADUser : OMI_BaseResource
     [Write, Description("Specifies whether the account requires a password. A password is not required for a new account. This parameter sets the PasswordNotRequired property of an account object.")] Boolean PasswordNotRequired;
     [Write, Description("Specifies whether a smart card is required to logon. This parameter sets the SmartCardLoginRequired property for a user object. This parameter also sets the ADS_UF_SMARTCARD_REQUIRED flag of the Active Directory User Account Control attribute.")] Boolean SmartcardLogonRequired;
     [Write, Description("Specifies the thumbnail photo to be used for the user object. Can be set either to a path pointing to a .jpg-file, or to a Base64-encoded jpeg image. If set to an empty string ('') the current thumbnail photo will be removed. The property ThumbnailPhoto will always return the image as a Base64-encoded string even if the configuration specified a file path.")] String ThumbnailPhoto;
+    [Write, Description("Specifies the description displayed on admin screens. Can be set to User_ to filter out an user from Entra ID Connect synchronization.")] String AdminDescription;
+    [Write, Description("Specifies the printable display name for an object. Can be set to a different display name to be used externally.")] String DisplayNamePrintable;
+    [Write, Description("The phonetic display name of an object. In the absence of a phonetic display name, the existing display name is used. (ldapDisplayName 'msDS-PhoneticDisplayName').")] String PhoneticDisplayName;
+    [Write, Description("The preferred written or spoken language for a person. For Microsoft 365, should follow ISO 639-1 Code, for example, en-US.")] String PreferredLanguage;
     [Read, Description("Returns the X.500 path of the object.")] String DistinguishedName;
     [Read, Description("Return the MD5 hash of the current thumbnail photo, or $null if no thumbnail photo exist.")] String ThumbnailPhotoHash;
 };

--- a/source/DSCResources/MSFT_ADUser/en-US/about_ADUser.help.txt
+++ b/source/DSCResources/MSFT_ADUser/en-US/about_ADUser.help.txt
@@ -258,10 +258,6 @@
     Write - String
     Specifies the description displayed on admin screens. Can be set to User_ to filter out an user from Entra ID Connect synchronization.
 
-.PARAMETER DisplayNamePrintable
-    Write - String
-    Specifies the printable display name for an object. Can be set to a different display name to be used externally.
-
 .PARAMETER PhoneticDisplayName
     Write - String
     The phonetic display name of an object. In the absence of a phonetic display name, the existing display name is used. (ldapDisplayName 'msDS-PhoneticDisplayName').
@@ -269,6 +265,10 @@
 .PARAMETER PreferredLanguage
     Write - String
     The preferred written or spoken language for a person. For Microsoft 365, should follow ISO 639-1 Code, for example, en-US.
+
+.PARAMETER SimpleDisplayName
+    Write - String
+    Specifies the printable display name for an object. Can be set to a different display name to be used externally. (ldapDisplayName 'displayNamePrintable').
 
 .PARAMETER DistinguishedName
     Read - String

--- a/source/DSCResources/MSFT_ADUser/en-US/about_ADUser.help.txt
+++ b/source/DSCResources/MSFT_ADUser/en-US/about_ADUser.help.txt
@@ -254,6 +254,22 @@
     Write - String
     Specifies the thumbnail photo to be used for the user object. Can be set either to a path pointing to a .jpg-file, or to a Base64-encoded jpeg image. If set to an empty string ('') the current thumbnail photo will be removed. The property ThumbnailPhoto will always return the image as a Base64-encoded string even if the configuration specified a file path.
 
+.PARAMETER AdminDescription
+    Write - String
+    Specifies the description displayed on admin screens. Can be set to User_ to filter out an user from Entra ID Connect synchronization.
+
+.PARAMETER DisplayNamePrintable
+    Write - String
+    Specifies the printable display name for an object. Can be set to a different display name to be used externally.
+
+.PARAMETER PhoneticDisplayName
+    Write - String
+    The phonetic display name of an object. In the absence of a phonetic display name, the existing display name is used. (ldapDisplayName 'msDS-PhoneticDisplayName').
+
+.PARAMETER PreferredLanguage
+    Write - String
+    The preferred written or spoken language for a person. For Microsoft 365, should follow ISO 639-1 Code, for example, en-US.
+
 .PARAMETER DistinguishedName
     Read - String
     Returns the X.500 path of the object.
@@ -382,5 +398,3 @@ Configuration ADUser_RemoveThumbnailPhoto_Config
         }
     }
 }
-
-

--- a/tests/Integration/MSFT_ADUser.config.ps1
+++ b/tests/Integration/MSFT_ADUser.config.ps1
@@ -89,6 +89,10 @@ else
                         PasswordNotRequired               = $false
                         SmartcardLogonRequired            = $false
                         ProxyAddresses                    = 'testuser1@fabrikam.com', 'testuser2@fabrikam.com'
+                        AdminDescription                  = 'User_'
+                        PhoneticDisplayName               = 'Test User Phonetic'
+                        PreferredLanguage                 = 'en-US'
+                        SimpleDisplayName                 = 'Test User Simple'
                         Ensure                            = 'Present'
                     }
                     ModifyUser = @{
@@ -176,6 +180,10 @@ Configuration MSFT_ADUser_CreateUser_Config
             PasswordNotRequired               = $Node.Tests.$testName.PasswordNotRequired
             SmartcardLogonRequired            = $Node.Tests.$testName.SmartcardLogonRequired
             ProxyAddresses                    = $Node.Tests.$testName.ProxyAddresses
+            AdminDescription                  = $Node.Tests.$testName.AdminDescription
+            PhoneticDisplayName               = $Node.Tests.$testName.PhoneticDisplayName
+            PreferredLanguage                 = $Node.Tests.$testName.PreferredLanguage
+            SimpleDisplayName                 = $Node.Tests.$testName.SimpleDisplayName
             Ensure                            = $Node.Tests.$testName.Ensure
         }
     }

--- a/tests/Unit/MSFT_ADUser.Tests.ps1
+++ b/tests/Unit/MSFT_ADUser.Tests.ps1
@@ -109,6 +109,10 @@ try
             PasswordNotRequired               = $false
             SmartcardLogonRequired            = $false
             ProxyAddresses                    = 'testuser1@fabrikam.com', 'testuser2@fabrikam.com'
+            AdminDescription                  = 'User_'
+            DisplayNamePrintable              = 'Test User Printable'
+            PhoneticDisplayName               = 'Test User Phonetic'
+            PreferredLanguage                 = 'en-US'
             Ensure                            = 'Present'
         }
 
@@ -169,6 +173,10 @@ try
             PasswordNotRequired               = $null
             SmartcardLogonRequired            = $null
             ProxyAddresses                    = $null
+            AdminDescription                  = $null
+            DisplayNamePrintable              = $null
+            PhoneticDisplayName               = $null
+            PreferredLanguage                 = $null
             Ensure                            = 'Absent'
         }
 
@@ -223,6 +231,10 @@ try
             PasswordNotRequired               = $true
             SmartcardLogonRequired            = $true
             ProxyAddresses                    = 'testuser3@fabrikam.com', 'testuser4@fabrikam.com'
+            AdminDescription                  = 'User_ Changed'
+            DisplayNamePrintable              = 'Test User Printable Changed'
+            PhoneticDisplayName               = 'Test User Phonetic Changed'
+            PreferredLanguage                 = 'en-GB'
         }
 
         $mockGetADUserResult = @{
@@ -278,6 +290,10 @@ try
             SmartcardLogonRequired            = $mockResource.SmartcardLogonRequired
             ServicePrincipalName              = $mockResource.ServicePrincipalNames
             ProxyAddresses                    = $mockResource.ProxyAddresses
+            AdminDescription                  = $mockResource.AdminDescription
+            DisplayNamePrintable              = $mockResource.DisplayNamePrintable
+            PhoneticDisplayName               = $mockResource.PhoneticDisplayName
+            PreferredLanguage                 = $mockResource.PreferredLanguage
         }
 
         $mockGetTargetResourceResult = $mockResource.Clone()

--- a/tests/Unit/MSFT_ADUser.Tests.ps1
+++ b/tests/Unit/MSFT_ADUser.Tests.ps1
@@ -291,9 +291,9 @@ try
             ServicePrincipalName              = $mockResource.ServicePrincipalNames
             ProxyAddresses                    = $mockResource.ProxyAddresses
             AdminDescription                  = $mockResource.AdminDescription
-            PhoneticDisplayName               = $mockResource.PhoneticDisplayName
+            'msDS-PhoneticDisplayName'        = $mockResource.PhoneticDisplayName
             PreferredLanguage                 = $mockResource.PreferredLanguage
-            SimpleDisplayName                 = $mockResource.SimpleDisplayName
+            displayNamePrintable              = $mockResource.SimpleDisplayName
         }
 
         $mockGetTargetResourceResult = $mockResource.Clone()

--- a/tests/Unit/MSFT_ADUser.Tests.ps1
+++ b/tests/Unit/MSFT_ADUser.Tests.ps1
@@ -110,9 +110,9 @@ try
             SmartcardLogonRequired            = $false
             ProxyAddresses                    = 'testuser1@fabrikam.com', 'testuser2@fabrikam.com'
             AdminDescription                  = 'User_'
-            DisplayNamePrintable              = 'Test User Printable'
             PhoneticDisplayName               = 'Test User Phonetic'
             PreferredLanguage                 = 'en-US'
+            SimpleDisplayName                 = 'Test User Simple'
             Ensure                            = 'Present'
         }
 
@@ -174,9 +174,9 @@ try
             SmartcardLogonRequired            = $null
             ProxyAddresses                    = $null
             AdminDescription                  = $null
-            DisplayNamePrintable              = $null
             PhoneticDisplayName               = $null
             PreferredLanguage                 = $null
+            SimpleDisplayName                 = $null
             Ensure                            = 'Absent'
         }
 
@@ -232,9 +232,9 @@ try
             SmartcardLogonRequired            = $true
             ProxyAddresses                    = 'testuser3@fabrikam.com', 'testuser4@fabrikam.com'
             AdminDescription                  = 'User_ Changed'
-            DisplayNamePrintable              = 'Test User Printable Changed'
             PhoneticDisplayName               = 'Test User Phonetic Changed'
             PreferredLanguage                 = 'en-GB'
+            SimpleDisplayName                 = 'Test User Simple Changed'
         }
 
         $mockGetADUserResult = @{
@@ -291,9 +291,9 @@ try
             ServicePrincipalName              = $mockResource.ServicePrincipalNames
             ProxyAddresses                    = $mockResource.ProxyAddresses
             AdminDescription                  = $mockResource.AdminDescription
-            DisplayNamePrintable              = $mockResource.DisplayNamePrintable
             PhoneticDisplayName               = $mockResource.PhoneticDisplayName
             PreferredLanguage                 = $mockResource.PreferredLanguage
+            SimpleDisplayName                 = $mockResource.SimpleDisplayName
         }
 
         $mockGetTargetResourceResult = $mockResource.Clone()


### PR DESCRIPTION
#### Pull Request (PR) description

Adds support for Windows Server 2025 Forest and Domain functional levels
Adds support for some new attributes in ADUser

#### This Pull Request (PR) fixes the following issues

- Fixes #721 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ActiveDirectoryDsc/730)
<!-- Reviewable:end -->
