### PR TITLE
ADGroup: Support for adminDescription attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - ADUser
   - Support for AdminDescription, PhoneticDisplayName, PreferredLanguage and
     SimpleDisplayName attributes.
+- ADGroup
+  - Support for AdminDescription attribute.
 
 ## [6.6.2] - 2025-03-17
 

--- a/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.schema.mof
+++ b/source/DSCResources/MSFT_ADGroup/MSFT_ADGroup.schema.mof
@@ -16,6 +16,7 @@ class MSFT_ADGroup : OMI_BaseResource
     [Write, Description("Active Directory attribute used to perform membership operations. Default value is 'SamAccountName'."), ValueMap{"SamAccountName","DistinguishedName","ObjectGUID","SID"}, Values{"SamAccountName","DistinguishedName","ObjectGUID","SID"}] String MembershipAttribute;
     [Write, Description("Active Directory managed by attribute specified as a DistinguishedName.")] String ManagedBy;
     [Write, Description("Active Directory group notes field.")] String Notes;
+    [Write, Description("Specifies the description displayed on admin screens. Can be set to Group_to filter out a group from Entra ID Connect synchronization.")] String AdminDescription;
     [Write, Description("Try to restore the group from the recycle bin before creating a new one.")] Boolean RestoreFromRecycleBin;
     [Read, Description("Returns the distinguished name of the Active Directory group.")] String DistinguishedName;
 };

--- a/source/DSCResources/MSFT_ADGroup/en-US/about_ADGroup.help.txt
+++ b/source/DSCResources/MSFT_ADGroup/en-US/about_ADGroup.help.txt
@@ -76,6 +76,10 @@
     Write - String
     Active Directory group notes field.
 
+.PARAMETER AdminDescription
+    Write - String
+    Specifies the description displayed on admin screens. Can be set to Group_to filter out a group from Entra ID Connect synchronization.
+
 .PARAMETER RestoreFromRecycleBin
     Write - Boolean
     Try to restore the group from the recycle bin before creating a new one.
@@ -167,5 +171,3 @@ Configuration ADGroup_NewGroupMultiDomainMembers_Config
         }
     }
 }
-
-

--- a/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
+++ b/source/DSCResources/MSFT_ADUser/MSFT_ADUser.schema.mof
@@ -32,7 +32,7 @@ class MSFT_ADUser : OMI_BaseResource
     [Write, Description("Specifies the URL of the home page of the object (ldapDisplayName 'wWWHomePage').")] String HomePage;
     [Write, Description("Specifies a path to the user's profile (ldapDisplayName 'profilePath').")] String ProfilePath;
     [Write, Description("Specifies a path to the user's log on script (ldapDisplayName 'scriptPath').")] String LogonScript;
-    [Write, Description("Specifies the notes attached to the user's accoutn (ldapDisplayName 'info').")] String Notes;
+    [Write, Description("Specifies the notes attached to the user's account (ldapDisplayName 'info').")] String Notes;
     [Write, Description("Specifies the user's office telephone number (ldapDisplayName 'telephoneNumber').")] String OfficePhone;
     [Write, Description("Specifies the user's mobile phone number (ldapDisplayName 'mobile').")] String MobilePhone;
     [Write, Description("Specifies the user's fax phone number (ldapDisplayName 'facsimileTelephoneNumber').")] String Fax;

--- a/source/DSCResources/MSFT_ADUser/en-US/about_ADUser.help.txt
+++ b/source/DSCResources/MSFT_ADUser/en-US/about_ADUser.help.txt
@@ -139,7 +139,7 @@
 
 .PARAMETER Notes
     Write - String
-    Specifies the notes attached to the user's accoutn (ldapDisplayName 'info').
+    Specifies the notes attached to the user's account (ldapDisplayName 'info').
 
 .PARAMETER OfficePhone
     Write - String

--- a/tests/Integration/MSFT_ADGroup.config.ps1
+++ b/tests/Integration/MSFT_ADGroup.config.ps1
@@ -34,27 +34,29 @@ else
 
                 Tests                   = [Ordered]@{
                     CreateGroup               = @{
-                        GroupName   = $groupName
-                        GroupScope  = 'Global'
-                        Category    = 'Security'
-                        Path        = "CN=Users,$domainDistinguishedName"
-                        Description = 'Original Description'
-                        DisplayName = 'Display Name'
-                        Members     = 'Administrator', 'Guest'
-                        ManagedBy   = "CN=Administrator,CN=Users,$domainDistinguishedName"
-                        Notes       = 'Notes'
-                        Ensure      = 'Present'
+                        GroupName         = $groupName
+                        GroupScope        = 'Global'
+                        Category          = 'Security'
+                        Path              = "CN=Users,$domainDistinguishedName"
+                        Description       = 'Original Description'
+                        DisplayName       = 'Display Name'
+                        AdminDescription  = 'Admin Description'
+                        Members           = 'Administrator', 'Guest'
+                        ManagedBy         = "CN=Administrator,CN=Users,$domainDistinguishedName"
+                        Notes             = 'Notes'
+                        Ensure            = 'Present'
                     }
                     ModifyGroup               = @{
-                        GroupName   = $groupName
-                        GroupScope  = 'DomainLocal'
-                        Category    = 'Distribution'
-                        Path        = "CN=Computers,$domainDistinguishedName"
-                        Description = 'Modified Description'
-                        DisplayName = 'Modified Display Name'
-                        Members     = 'Administrator'
-                        ManagedBy   = "CN=Guest,CN=Users,$domainDistinguishedName"
-                        Notes       = 'Modified Notes'
+                        GroupName         = $groupName
+                        GroupScope        = 'DomainLocal'
+                        Category          = 'Distribution'
+                        Path              = "CN=Computers,$domainDistinguishedName"
+                        Description       = 'Modified Description'
+                        DisplayName       = 'Modified Display Name'
+                        AdminDescription  = 'Modified Admin Description'
+                        Members           = 'Administrator'
+                        ManagedBy         = "CN=Guest,CN=Users,$domainDistinguishedName"
+                        Notes             = 'Modified Notes'
                     }
                     MembersToInclude          = @{
                         GroupName        = $groupName
@@ -98,6 +100,7 @@ Configuration MSFT_ADGroup_CreateGroup_Config
             Path                 = $Node.Tests.$testName.Path
             Description          = $Node.Tests.$testName.Description
             DisplayName          = $Node.Tests.$testName.DisplayName
+            AdminDescription     = $Node.Tests.$testName.AdminDescription
             Members              = $Node.Tests.$testName.Members
             ManagedBy            = $Node.Tests.$testName.ManagedBy
             Notes                = $Node.Tests.$testName.Notes
@@ -127,6 +130,7 @@ Configuration MSFT_ADGroup_ModifyGroup_Config
             Path                 = $Node.Tests.$testName.Path
             Description          = $Node.Tests.$testName.Description
             DisplayName          = $Node.Tests.$testName.DisplayName
+            AdminDescription     = $Node.Tests.$testName.AdminDescription
             Members              = $Node.Tests.$testName.Members
             ManagedBy            = $Node.Tests.$testName.ManagedBy
             Notes                = $Node.Tests.$testName.Notes

--- a/tests/Unit/MSFT_ADGroup.Tests.ps1
+++ b/tests/Unit/MSFT_ADGroup.Tests.ps1
@@ -37,15 +37,16 @@ try
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath 'Stubs\ActiveDirectory_2019.psm1') -Force
 
         $testPresentParams = @{
-            GroupName   = 'TestGroup'
-            GroupScope  = 'Global'
-            Category    = 'Security'
-            Path        = 'OU=OU,DC=contoso,DC=com'
-            Description = 'Test AD group description'
-            DisplayName = 'Test display name'
-            Ensure      = 'Present'
-            Notes       = 'This is a test AD group'
-            ManagedBy   = 'CN=User 1,CN=Users,DC=contoso,DC=com'
+            GroupName         = 'TestGroup'
+            GroupScope        = 'Global'
+            Category          = 'Security'
+            Path              = 'OU=OU,DC=contoso,DC=com'
+            Description       = 'Test AD group description'
+            DisplayName       = 'Test display name'
+            AdminDescription  = 'Group_'
+            Ensure            = 'Present'
+            Notes             = 'This is a test AD group'
+            ManagedBy         = 'CN=User 1,CN=Users,DC=contoso,DC=com'
         }
 
         $mockGroupName = 'TestGroup'
@@ -91,6 +92,7 @@ try
             Path              = $mockGroupPath
             Description       = 'Test AD group description'
             DisplayName       = 'Test display name'
+            AdminDescription  = 'Group_'
             Info              = 'This is a test AD group'
             ManagedBy         = 'CN=User 1,CN=Users,DC=contoso,DC=com'
             DistinguishedName = "CN=$mockGroupName,$mockGroupPath"
@@ -98,10 +100,11 @@ try
         }
 
         $mockADGroupChanged = @{
-            GroupScope  = 'Universal'
-            Description = 'Test AD group description changed'
-            DisplayName = 'Test display name changed'
-            ManagedBy   = 'CN=User 2,CN=Users,DC=contoso,DC=com'
+            GroupScope       = 'Universal'
+            Description      = 'Test AD group description changed'
+            DisplayName      = 'Test display name changed'
+            adminDescription = 'Group_ changed'
+            ManagedBy        = 'CN=User 2,CN=Users,DC=contoso,DC=com'
         }
 
         $mockGetTargetResourceResults = @{
@@ -111,6 +114,7 @@ try
             Path              = $mockADGroup.Path
             Description       = $mockADGroup.Description
             DisplayName       = $mockADGroup.DisplayName
+            AdminDescription  = $mockADGroup.AdminDescription
             Notes             = $mockADGroup.Info
             ManagedBy         = $mockADGroup.ManagedBy
             DistinguishedName = $mockADGroup.DistinguishedName
@@ -125,6 +129,7 @@ try
             Path              = $null
             Description       = $null
             DisplayName       = $null
+            AdminDescription  = $null
             Notes             = $null
             ManagedBy         = $null
             DistinguishedName = $null
@@ -166,6 +171,7 @@ try
                     $result.MembersToExclude | Should -BeNullOrEmpty
                     $result.MembershipAttribute | Should -Be 'SamAccountName'
                     $result.ManagedBy | Should -Be $mockADGroup.ManagedBy
+                    $result.AdminDescription | Should -Be $mockADGroup.AdminDescription
                     $result.Notes | Should -Be $mockADGroup.Info
                     $result.DistinguishedName | Should -Be $mockADGroup.DistinguishedName
                     $result.Members | Should -HaveCount $mockADGroupMembersAsADObjects.count
@@ -343,6 +349,7 @@ try
                     $result.MembersToExclude | Should -BeNullOrEmpty
                     $result.MembershipAttribute | Should -Be 'SamAccountName'
                     $result.ManagedBy | Should -BeNullOrEmpty
+                    $result.AdminDescription | Should -BeNullOrEmpty
                     $result.Notes | Should -BeNullOrEmpty
                     $result.DistinguishedName | Should -BeNullOrEmpty
                 }
@@ -363,16 +370,17 @@ try
         Describe 'ADGroup\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 $testTargetResourceParameters = @{
-                    GroupName   = $mockADGroup.GroupName
-                    GroupScope  = $mockADGroup.GroupScope
-                    Category    = $mockADGroup.GroupCategory
-                    Path        = $mockADGroup.Path
-                    Description = $mockADGroup.Description
-                    DisplayName = $mockADGroup.DisplayName
-                    ManagedBy   = $mockADGroup.ManagedBy
-                    Notes       = $mockADGroup.Info
-                    Members     = $mockADGroup.Members
-                    Ensure      = 'Present'
+                    GroupName        = $mockADGroup.GroupName
+                    GroupScope       = $mockADGroup.GroupScope
+                    Category         = $mockADGroup.GroupCategory
+                    Path             = $mockADGroup.Path
+                    Description      = $mockADGroup.Description
+                    DisplayName      = $mockADGroup.DisplayName
+                    ManagedBy        = $mockADGroup.ManagedBy
+                    AdminDescription = $mockADGroup.AdminDescription
+                    Notes            = $mockADGroup.Info
+                    Members          = $mockADGroup.Members
+                    Ensure           = 'Present'
                 }
 
                 $testTargetResourceParametersAbsent = $testTargetResourceParameters.Clone()
@@ -546,16 +554,17 @@ try
         Describe 'ADGroup\Set-TargetResource' -Tag 'Set' {
             BeforeAll {
                 $setTargetResourceParameters = @{
-                    GroupName   = $mockADGroup.GroupName
-                    GroupScope  = $mockADGroup.GroupScope
-                    Category    = $mockADGroup.GroupCategory
-                    Path        = $mockADGroup.Path
-                    Description = $mockADGroup.Description
-                    DisplayName = $mockADGroup.DisplayName
-                    ManagedBy   = $mockADGroup.ManagedBy
-                    Notes       = $mockADGroup.Info
-                    Members     = $mockADGroup.Members
-                    Ensure      = 'Present'
+                    GroupName        = $mockADGroup.GroupName
+                    GroupScope       = $mockADGroup.GroupScope
+                    Category         = $mockADGroup.GroupCategory
+                    Path             = $mockADGroup.Path
+                    Description      = $mockADGroup.Description
+                    DisplayName      = $mockADGroup.DisplayName
+                    ManagedBy        = $mockADGroup.ManagedBy
+                    AdminDescription = $mockADGroup.AdminDescription
+                    Notes            = $mockADGroup.Info
+                    Members          = $mockADGroup.Members
+                    Ensure           = 'Present'
                 }
 
                 $setTargetResourceParametersAbsent = $setTargetResourceParameters.Clone()
@@ -845,6 +854,37 @@ try
                                 -ParameterFilter { `
                                     $Identity -eq $mockGroupDN -and (Get-Variable -Name Replace -ValueOnly).Info -eq `
                                     $setTargetResourceParametersChangedProperty.Notes } `
+                                -Exactly -Times 1
+                            Assert-MockCalled -CommandName Remove-ADGroup `
+                                -Exactly -Times 0
+                            Assert-MockCalled -CommandName New-ADGroup `
+                                -Exactly -Times 0
+                            Assert-MockCalled -CommandName Restore-ADCommonObject `
+                                -Exactly -Times 0
+                            Assert-MockCalled -CommandName Set-ADCommonGroupMember `
+                                -Exactly -Times 0
+                        }
+                    }
+
+
+                    Context "When the 'AdminDescription' property has changed" {
+                        BeforeAll {
+                            $setTargetResourceParametersChangedProperty = $setTargetResourceParameters.Clone()
+                            $setTargetResourceParametersChangedProperty.AdminDescription = 'Changed Admin Description'
+                        }
+
+                        It 'Should not throw' {
+                            { Set-TargetResource @setTargetResourceParametersChangedProperty } | Should -Not -Throw
+                        }
+
+                        It "Should call the expected mocks" {
+                            Assert-MockCalled -CommandName Get-TargetResource `
+                                -ParameterFilter { $GroupName -eq $setTargetResourceParametersChangedProperty.GroupName } `
+                                -Exactly -Times 1
+                            Assert-MockCalled -CommandName Set-ADGroup `
+                                -ParameterFilter { `
+                                    $Identity -eq $mockGroupDN -and (Get-Variable -Name Replace -ValueOnly).adminDescription -eq `
+                                    $setTargetResourceParametersChangedProperty.AdminDescription } `
                                 -Exactly -Times 1
                             Assert-MockCalled -CommandName Remove-ADGroup `
                                 -Exactly -Times 0


### PR DESCRIPTION
#### Pull Request (PR) description

Adds support for adminDescription attribute in ADGroup, allowing (amongst other things) on-premises groups to be filtered from Entra ID.

#### This Pull Request (PR) fixes the following issues

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
