### PR TITLE
ADDomain: Fix behaviour during pending DC promotion reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Add doc generation.
   - Move module to buildModule directory.
   - Add wiki to release assets.
+- ADDomain
+  - Skip LCM reboot signal if `dsc.exe` is running.
+    ([issue #742](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/742)).
+
+### Fixed
+
+- ADDomain
+  - Report domain exists in `Get-TargetResource` during pending DC promotion reboot.
+    ([issue #742](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/742)).
 
 ## [6.7.0] - 2025-05-29
 

--- a/source/DSCResources/MSFT_ADDomain/en-US/MSFT_ADDomain.strings.psd1
+++ b/source/DSCResources/MSFT_ADDomain/en-US/MSFT_ADDomain.strings.psd1
@@ -10,4 +10,5 @@ ConvertFrom-StringData @'
     DomainNotInDesiredState            = The domain '{0}' is NOT in the desired state. (ADD0009)
     SysVolPathDoesNotExistError        = The expected SysVol Path '{0}' does not exist. (ADD0011)
     GetAdForestUnexpectedError         = Error getting AD forest '{0}'. (ADD0014)
+    PendingReboot                      = Promotion pending reboot. (ADD0015)
 '@


### PR DESCRIPTION
#### Pull Request (PR) description

`ADDomain` now reports the domain as existing in `Get-TargetResource` when a DC promotion pending reboot is detected.
This prevents failures due to the DC being unreachable and ensures `Set-TargetResource` remains idempotent.

`Set-TargetResource` now checks for a pending DC promotion reboot and signals the LCM to reboot when the domain exists.

The reboot signal is skipped if `dsc.exe` is running.

#### This Pull Request (PR) fixes the following issues

- Fixes #742 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
