### PR TITLE
ADObjectPermissionEntry: Fix Get-TargetResource ActiveDirectoryRights type for absent ACE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Migrate tests to Pester 5.
   - Add VSCode settings for Pester Extension.
 
+### Fixed
+
+- ADObjectPermissionEntry
+  - Fixed Get-TargetResource to return valid ActiveDirectoryRights when ACE is absent
+
 ## [6.7.0] - 2025-05-29
 
 ### Added

--- a/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
+++ b/source/DSCResources/MSFT_ADObjectPermissionEntry/MSFT_ADObjectPermissionEntry.psm1
@@ -74,7 +74,7 @@ function Get-TargetResource
         Ensure                             = 'Absent'
         Path                               = $Path
         IdentityReference                  = $IdentityReference
-        ActiveDirectoryRights              = ''
+        ActiveDirectoryRights              = [System.String[]] @()
         AccessControlType                  = $AccessControlType
         ObjectType                         = $ObjectType
         ActiveDirectorySecurityInheritance = $ActiveDirectorySecurityInheritance

--- a/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
+++ b/tests/Unit/MSFT_ADObjectPermissionEntry.Tests.ps1
@@ -111,7 +111,7 @@ Describe 'MSFT_ADObjectPermissionEntry\Get-TargetResource' -Tag 'Get' {
                 $targetResource.Ensure | Should -Be 'Present'
                 $targetResource.Path | Should -Be $testDefaultParameters.Path
                 $targetResource.IdentityReference | Should -Be $testDefaultParameters.IdentityReference
-                $targetResource.ActiveDirectoryRights | Should -Be 'GenericAll'
+                $targetResource.ActiveDirectoryRights | Should -Be @('GenericAll')
                 $targetResource.AccessControlType | Should -Be $testDefaultParameters.AccessControlType
                 $targetResource.ObjectType | Should -Be $testDefaultParameters.ObjectType
                 $targetResource.ActiveDirectorySecurityInheritance | Should -Be $testDefaultParameters.ActiveDirectorySecurityInheritance
@@ -157,7 +157,7 @@ Describe 'MSFT_ADObjectPermissionEntry\Get-TargetResource' -Tag 'Get' {
                 $targetResource.Ensure | Should -Be 'Absent'
                 $targetResource.Path | Should -Be $testDefaultParameters.Path
                 $targetResource.IdentityReference | Should -Be $testDefaultParameters.IdentityReference
-                $targetResource.ActiveDirectoryRights | Should -Be ''
+                $targetResource.ActiveDirectoryRights | Should -Be @()
                 $targetResource.AccessControlType | Should -Be $testDefaultParameters.AccessControlType
                 $targetResource.ObjectType | Should -Be $testDefaultParameters.ObjectType
                 $targetResource.ActiveDirectorySecurityInheritance | Should -Be $testDefaultParameters.ActiveDirectorySecurityInheritance


### PR DESCRIPTION
#### Pull Request (PR) description

When ADObjectPermissionEntry is invoked with the `Get` method, the LCM can fail with:

```
A general error occurred that is not covered by a more specific error code.
    + CategoryInfo          : NotSpecified: (root/Microsoft/...gurationManager:String) [], CimException
    + FullyQualifiedErrorId : MI RESULT 1
    + PSComputerName        : localhost
```

`Get-TargetResource` returns an empty string for `ActiveDirectoryRights` when the ACE is absent. This violates the schema and causes MI marshalling to fail. The fix changes the default return value to be an empty string array.

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ActiveDirectoryDsc/746)
<!-- Reviewable:end -->
