### PR TITLE
Update Pester to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Changed
+
+- `ActiveDirectoryDsc`
+  - Updated unit tests for Pester 6 compatibility - forward unmatched `Test-Path`
+    mock calls to the real cmdlet, suppress unmatched `Write-Verbose` calls, and
+    replace the removed `Assert-VerifiableMock` with `Should -InvokeVerifiable`.
+
 ## [6.7.1] - 2025-12-05
 
 ### Added

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -9,9 +9,7 @@
 
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
-    Pester                         = @{
-        Version = '6.0.0'
-    }
+    Pester                         = 'latest'
     Plaster                        = 'latest'
     ModuleBuilder                  = 'latest'
     ChangelogManagement            = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -10,8 +10,7 @@
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
     Pester                         = @{
-        Version    = '6.0.0-rc4'
-        Parameters = @{ AllowPrerelease = $true }
+        Version = '6.0.0'
     }
     Plaster                        = 'latest'
     ModuleBuilder                  = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -9,7 +9,10 @@
 
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
-    Pester                         = 'latest'
+    Pester                         = @{
+        Version    = '6.0.0-rc1'
+        Parameters = @{ AllowPrerelease = $true }
+    }
     Plaster                        = 'latest'
     ModuleBuilder                  = 'latest'
     ChangelogManagement            = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -10,7 +10,7 @@
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
     Pester                         = @{
-        Version    = '6.0.0-rc1'
+        Version    = '6.0.0-rc2'
         Parameters = @{ AllowPrerelease = $true }
     }
     Plaster                        = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -10,7 +10,7 @@
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
     Pester                         = @{
-        Version    = '6.0.0-rc2'
+        Version    = '6.0.0-rc4'
         Parameters = @{ AllowPrerelease = $true }
     }
     Plaster                        = 'latest'

--- a/tests/Unit/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.Tests.ps1
+++ b/tests/Unit/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.Tests.ps1
@@ -1647,6 +1647,9 @@ Describe 'ActiveDirectoryDsc.Common\Find-DomainController' -Tag 'FindDomainContr
                 )
             }
 
+            # Pester v6 throws instead of calling the real command when no -ParameterFilter
+            # matches. Suppress unmatched Write-Verbose calls (v5 let them through).
+            Mock -CommandName Write-Verbose -MockWith { }
             Mock -CommandName Write-Verbose -ParameterFilter {
                 $Message -like 'Searching for a domain controller*'
             } -MockWith {
@@ -1658,7 +1661,9 @@ Describe 'ActiveDirectoryDsc.Common\Find-DomainController' -Tag 'FindDomainContr
             { Find-DomainController -DomainName $mockDomainName } | Should -Not -Throw
 
             Should -Invoke -CommandName Find-DomainControllerFindOneWrapper -Exactly -Times 1 -Scope It
-            Should -Invoke -CommandName Write-Verbose -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Write-Verbose -ParameterFilter {
+                $Message -like 'Searching for a domain controller*'
+            } -Exactly -Times 1 -Scope It
         }
 
         Should -InvokeVerifiable

--- a/tests/Unit/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.Tests.ps1
+++ b/tests/Unit/ActiveDirectoryDsc.Common/ActiveDirectoryDsc.Common.Tests.ps1
@@ -756,7 +756,7 @@ Describe 'ActiveDirectoryDsc.Common\Restore-ADCommonObject' {
         }
 
         It 'Should call Get-ADObject as well as Restore-ADObject' {
-            Assert-VerifiableMock
+            Should -InvokeVerifiable
         }
 
         It 'Should throw an InvalidOperationException when object parent does not exist' {
@@ -1558,7 +1558,7 @@ Describe 'ActiveDirectoryDsc.Common\Get-ADDirectoryContext' {
             }
         }
 
-        Assert-VerifiableMock
+        Should -InvokeVerifiable
     }
 }
 
@@ -1625,7 +1625,7 @@ Describe 'ActiveDirectoryDsc.Common\Find-DomainController' -Tag 'FindDomainContr
             }
         }
 
-        Assert-VerifiableMock
+        Should -InvokeVerifiable
     }
 
     Context 'When no domain controller is found' {
@@ -1661,7 +1661,7 @@ Describe 'ActiveDirectoryDsc.Common\Find-DomainController' -Tag 'FindDomainContr
             Should -Invoke -CommandName Write-Verbose -Exactly -Times 1 -Scope It
         }
 
-        Assert-VerifiableMock
+        Should -InvokeVerifiable
     }
 
     Context 'When the lookup for a domain controller fails' {
@@ -1686,7 +1686,7 @@ Describe 'ActiveDirectoryDsc.Common\Find-DomainController' -Tag 'FindDomainContr
             Should -Invoke -CommandName Find-DomainControllerFindOneWrapper -Exactly -Times 1 -Scope It
         }
 
-        Assert-VerifiableMock
+        Should -InvokeVerifiable
     }
 
     Context 'When the Find-DomainController throws an authentication exception' {

--- a/tests/Unit/MSFT_ADDomain.Tests.ps1
+++ b/tests/Unit/MSFT_ADDomain.Tests.ps1
@@ -62,6 +62,9 @@ AfterAll {
 Describe 'MSFT_ADDomain\Get-TargetResource' -Tag 'Get' {
     BeforeAll {
         Mock -CommandName Assert-Module
+        # Pester v6 throws instead of calling the real command when no -ParameterFilter
+        # matches. Forward unmatched Test-Path calls to the real cmdlet to keep v5 behaviour.
+        Mock -CommandName Test-Path -MockWith { & (Get-Command -Name 'Test-Path' -CommandType Cmdlet) @PesterBoundParameters }
         Mock -CommandName Test-Path -ParameterFilter {
             $Path -eq 'C:\Windows\SysVol\contoso.com'
         } -MockWith { $true }
@@ -675,6 +678,9 @@ Describe 'MSFT_ADDomain\Set-TargetResource' -Tag 'Set' {
         Context 'When the domain controller is pending reboot and SuppressReboot is $false' {
             BeforeAll {
                 # Make the resource think a reboot is pending after installation.
+                # Pester v6 throws instead of calling the real command when no -ParameterFilter
+                # matches. Forward unmatched Test-Path calls to the real cmdlet to keep v5 behaviour.
+                Mock -CommandName Test-Path -MockWith { & (Get-Command -Name 'Test-Path' -CommandType Cmdlet) @PesterBoundParameters }
                 Mock -CommandName Test-Path -ParameterFilter {
                     $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters\LocatorDCPromoPreRebootHint'
                 } -MockWith { $true }
@@ -1078,6 +1084,9 @@ Describe 'MSFT_ADDomain\Set-TargetResource' -Tag 'Set' {
 
         Context 'When the domain controller is pending reboot and SuppressReboot is $false' {
             BeforeAll {
+                # Pester v6 throws instead of calling the real command when no -ParameterFilter
+                # matches. Forward unmatched Test-Path calls to the real cmdlet to keep v5 behaviour.
+                Mock -CommandName Test-Path -MockWith { & (Get-Command -Name 'Test-Path' -CommandType Cmdlet) @PesterBoundParameters }
                 Mock -CommandName Test-Path -ParameterFilter {
                     $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters\LocatorDCPromoPreRebootHint'
                 } -MockWith { $true }

--- a/tests/Unit/MSFT_WaitForADDomain.Tests.ps1
+++ b/tests/Unit/MSFT_WaitForADDomain.Tests.ps1
@@ -157,6 +157,9 @@ Describe 'MSFT_WaitForADDomain\Get-TargetResource' -Tag 'Get' {
 
             Context 'When using BuiltInCredential parameter' {
                 BeforeAll {
+                    # Pester v6 throws instead of calling the real command when no -ParameterFilter
+                    # matches. Suppress unmatched Write-Verbose calls (v5 let them through).
+                    Mock -CommandName Write-Verbose -MockWith { }
                     Mock -CommandName Write-Verbose -ParameterFilter {
                         $Message -like 'Impersonating the credentials ''BuiltInCredential''*'
                     } -MockWith {
@@ -185,7 +188,9 @@ Describe 'MSFT_WaitForADDomain\Get-TargetResource' -Tag 'Get' {
                         $result.Credential | Should -BeNullOrEmpty
                     }
 
-                    Should -Invoke -CommandName Write-Verbose -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Write-Verbose -ParameterFilter {
+                        $Message -like 'Impersonating the credentials ''BuiltInCredential''*'
+                    } -Exactly -Times 1 -Scope It
                 }
             }
         }


### PR DESCRIPTION
Pester **6.0.0 is now released** 🎉 — thanks for letting me pilot the release candidates against your suite.

This updates the earlier release-candidate pin to the final **6.0.0** and keeps the test changes needed to run on Pester 6 (already in this PR). It's the same migration you'd make yourself, so you're welcome to merge it, cherry-pick just the compatibility changes, or use it purely as a reference.

Your unit tests pass on 6.0.0. The remaining red **HQRM** check is this repo's own custom PSScriptAnalyzer rules (e.g. `Measure-Keyword`), unrelated to Pester.

The real-world CI signal from this pilot was genuinely valuable in getting 6.0.0 right. Thanks for the CI time this used, and for maintaining a suite I could test against.

This PR was co-authored by GitHub Copilot.

— Jakub & Copilot

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ActiveDirectoryDsc/751)
<!-- Reviewable:end -->
